### PR TITLE
ivs: get build id from the environment

### DIFF
--- a/.abat-automerge
+++ b/.abat-automerge
@@ -23,6 +23,8 @@ cd "$ROOTDIR"
 ./build/setup.sh
 ./build/precheckin.py
 
+export BUILD_ID=$(date +'%F.%R%z')-$(git rev-parse -q --short HEAD)
+
 ARCHS="i386 amd64"
 SUITES="oneiric precise"
 for ARCH in $ARCHS; do

--- a/build/build-debian-packages.sh
+++ b/build/build-debian-packages.sh
@@ -26,9 +26,10 @@ else
     : Arch: ${ARCH:=i386}
 fi
 
+: Build ID: ${BUILD_ID:=devel}
+
 BASEPATH="/var/cache/pbuilder/base-${SUITE}-${ARCH}.cow"
-BUILD=$(date +'%F.%R%z')-$(git rev-parse -q --short HEAD)
-OUTDIR=$(readlink -m "pkg/$SUITE-$ARCH/$BUILD")
+OUTDIR=$(readlink -m "pkg/$SUITE-$ARCH/$BUILD_ID")
 
 if [ ! -d ${BASEPATH} ]; then
     sudo cowbuilder --create \
@@ -59,6 +60,6 @@ pdebuild --pbuilder cowbuilder \
 cd -
 rm -rf "$COPY"
 git log > "$OUTDIR/gitlog.txt"
-touch "$OUTDIR/build-$BUILD"
+touch "$OUTDIR/build-$BUILD_ID"
 
 ln -snf $(basename $OUTDIR) $OUTDIR/../latest

--- a/targets/ivs/Makefile
+++ b/targets/ivs/Makefile
@@ -166,8 +166,10 @@ LIBNL_LIBS += $(shell pkg-config --libs --silence-errors libnl-route-3.0)
 GLOBAL_CFLAGS += $(LIBNL_CFLAGS)
 GLOBAL_LINK_LIBS += $(LIBNL_LIBS)
 
+ifdef BUILD_ID
+GLOBAL_CFLAGS += "-DBUILD_ID=$(BUILD_ID)"
+endif
+
 
 ucli:
 	$(INDIGO)/Tools/uclihandlers.py ucli.c
-
-$(shell (echo -n '#define GIT_REVISION '; git rev-parse -q --short HEAD) > git_revision.h)

--- a/targets/ivs/main.c
+++ b/targets/ivs/main.c
@@ -41,7 +41,6 @@
 #include <arpa/inet.h>
 #include <signal.h>
 #include <sys/eventfd.h>
-#include "git_revision.h"
 
 #define AIM_LOG_MODULE_NAME ivs
 #include <AIM/aim_log.h>
@@ -194,7 +193,11 @@ parse_options(int argc, char **argv)
             break;
 
         case OPT_VERSION:
-            printf("%s (%s)\n", program_version, AIM_STRINGIFY(GIT_REVISION));
+            printf("%s", program_version);
+#ifdef BUILD_ID
+            printf(" (%s)", AIM_STRINGIFY(BUILD_ID));
+#endif
+            printf("\n");
             exit(0);
             break;
 


### PR DESCRIPTION
Reviewer: @poolakiran

This fixes the build id for builds outside of a git repo (such as when
building debian packages).
