### PR TITLE
OVSDriver: use CFR when checking for overlapping kflows

### DIFF
--- a/Modules/OVSDriver/module/src/fwd.c
+++ b/Modules/OVSDriver/module/src/fwd.c
@@ -214,7 +214,7 @@ indigo_fwd_flow_create(indigo_cookie_t flow_id,
     flowtable_insert(ind_ovs_ft, &flow->fte);
     ind_ovs_fwd_write_unlock();
 
-    ind_ovs_kflow_invalidate_overlap(&of_match, flow->fte.priority);
+    ind_ovs_kflow_invalidate_overlap(&fields, &masks, flow->fte.priority);
 
     ++active_count;
 

--- a/Modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/Modules/OVSDriver/module/src/ovs_driver_int.h
@@ -279,7 +279,7 @@ void ind_ovs_fwd_write_unlock();
 indigo_error_t ind_ovs_kflow_add(struct ind_ovs_flow *flow, const struct nlattr *key, const struct nlattr *actions);
 void ind_ovs_kflow_sync_stats(struct ind_ovs_kflow *kflow);
 void ind_ovs_kflow_invalidate(struct ind_ovs_kflow *kflow);
-void ind_ovs_kflow_invalidate_overlap(of_match_t *match, uint16_t priority);
+void ind_ovs_kflow_invalidate_overlap(const struct ind_ovs_cfr *flow_fields, const struct ind_ovs_cfr *flow_masks, uint16_t priority);
 void ind_ovs_kflow_invalidate_flood(void);
 void ind_ovs_kflow_expire(void);
 void ind_ovs_kflow_module_init(void);


### PR DESCRIPTION
Reviewer: @poolakiran

With the introduction of the meta_id match fields the OVS flow key is no
longer a superset of the OpenFlow match. This broke
ind_ovs_kflow_invalidate_overlap, which translated the kflow key into an
of_match and compared it with the of_match sent by the controller (which may
have had the meta_id fields un-wildcarded).

The fix, which should also be more performant, is to translate the of_match
and kflow key into a CFR.
