### PR TITLE
Memory leak fix in OVSDriver.

### DIFF
--- a/Modules/OVSDriver/module/src/fwd.c
+++ b/Modules/OVSDriver/module/src/fwd.c
@@ -553,6 +553,7 @@ indigo_fwd_packet_out(of_packet_out_t *of_packet_out)
         assert(nlh->nlmsg_seq == nlmsg_hdr(msg)->nlmsg_seq);
         LOG_ERROR("Kernel failed to parse packet-out data");
         ind_ovs_nlmsg_freelist_free(msg);
+        ind_ovs_nlmsg_freelist_free(reply_msg);
         return INDIGO_ERROR_UNKNOWN;
     }
 

--- a/Modules/OVSDriver/module/src/upcall.c
+++ b/Modules/OVSDriver/module/src/upcall.c
@@ -342,6 +342,8 @@ ind_ovs_handle_packet_table(struct ind_ovs_upcall_thread *thread,
     if (nla_len(actions) > 0) {
         nl_send_auto(port->notify_socket, reply);
     }
+
+    ind_ovs_nlmsg_freelist_free(reply);
 }
 
 static void


### PR DESCRIPTION
Reviewer: @rlane
Also has debug code to allocate each nlmsg seperately to debeg nlmsg leaks using valgrind.
