### PR TITLE
Generic flow table integration with OVSDriver

### DIFF
--- a/Modules/OVSDriver/module/src/bh.c
+++ b/Modules/OVSDriver/module/src/bh.c
@@ -163,7 +163,7 @@ ind_ovs_bh_run()
 
             /* Lookup the flow in the userspace flowtable. */
             struct flowtable_entry *fte =
-                flowtable_match(ind_ovs_ft, (struct flowtable_key *)&cfr);
+                flowtable_generic_match(ind_ovs_ftg, (struct flowtable_key *)&cfr);
             if (fte != NULL) {
                 struct ind_ovs_flow *flow = container_of(fte, fte, struct ind_ovs_flow);
                 if (ind_ovs_kflow_add(flow, key, actions) < 0) {

--- a/Modules/OVSDriver/module/src/fwd.c
+++ b/Modules/OVSDriver/module/src/fwd.c
@@ -31,7 +31,7 @@
 #include <pthread.h>
 #include <errno.h>
 
-struct flowtable *ind_ovs_ft;
+struct flowtable_generic *ind_ovs_ftg;
 
 static struct list_head ind_ovs_flow_id_buckets[64];
 
@@ -211,7 +211,7 @@ indigo_fwd_flow_create(indigo_cookie_t flow_id,
     list_push(flow_id_bucket, &flow->flow_id_links);
 
     ind_ovs_fwd_write_lock();
-    flowtable_insert(ind_ovs_ft, &flow->fte);
+    flowtable_generic_insert(ind_ovs_ftg, &flow->fte);
     ind_ovs_fwd_write_unlock();
 
     ind_ovs_kflow_invalidate_overlap(&fields, &masks, flow->fte.priority);
@@ -293,7 +293,7 @@ indigo_fwd_flow_delete(indigo_cookie_t flow_id,
     }
 
     ind_ovs_fwd_write_lock();
-    flowtable_remove(ind_ovs_ft, &flow->fte);
+    flowtable_generic_remove(ind_ovs_ftg, &flow->fte);
     ind_ovs_fwd_write_unlock();
 
     ind_ovs_flow_invalidate_kflows(flow);
@@ -482,7 +482,7 @@ ind_ovs_lookup_flow(const struct ind_ovs_parsed_key *pkey,
 
     ++lookup_count;
 
-    fte = flowtable_match(ind_ovs_ft, (struct flowtable_key *)&cfr);
+    fte = flowtable_generic_match(ind_ovs_ftg, (struct flowtable_key *)&cfr);
     if (fte == NULL) {
         return INDIGO_ERROR_NOT_FOUND;
     }
@@ -633,8 +633,8 @@ ind_ovs_fwd_init(void)
     memset(&hash_mask, 0, sizeof(hash_mask));
     memset(&hash_mask.dl_dst, 0xff, sizeof(&hash_mask.dl_dst));
     memset(&hash_mask.dl_src, 0xff, sizeof(&hash_mask.dl_src));
-    ind_ovs_ft = flowtable_create((struct flowtable_key *)&hash_mask);
-    if (!ind_ovs_ft) {
+    ind_ovs_ftg = flowtable_generic_create();
+    if (!ind_ovs_ftg) {
         return INDIGO_ERROR_RESOURCE;
     }
 
@@ -664,7 +664,7 @@ ind_ovs_fwd_finish(void)
     /* Hold this forever. */
     ind_ovs_fwd_write_lock();
 
-    flowtable_destroy(ind_ovs_ft);
+    flowtable_generic_destroy(ind_ovs_ftg);
 
     /* Free all the flows */
     for (i = 0; i < ARRAY_SIZE(ind_ovs_flow_id_buckets); i++) {

--- a/Modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/Modules/OVSDriver/module/src/ovs_driver_int.h
@@ -34,6 +34,7 @@
 #include "AIM/aim_rl.h"
 #include "AIM/aim_utils.h"
 #include "flowtable/flowtable.h"
+#include "flowtable/flowtable_generic.h"
 
 #define IND_OVS_MAX_PORTS 1024
 
@@ -398,9 +399,9 @@ extern uint32_t ind_ovs_salt;
 extern int ind_ovs_version;
 
 /*
- * Flowtable. Protected by ind_ovs_fwd_{read,write}_{lock,unlock}.
+ * Generic Flowtable. Protected by ind_ovs_fwd_{read,write}_{lock,unlock}.
  */
-extern struct flowtable *ind_ovs_ft;
+extern struct flowtable_generic *ind_ovs_ftg;
 
 /*
  * Configuration for the bsn_pktin_suppression extension.


### PR DESCRIPTION
Reviewer: @rlane
OVSDriver is changed to use the Generic flow table APIs in the place of Flowtable APIs.
