### PR TITLE
OpenFlow 1.3 VLAN matching

### DIFF
--- a/Modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/Modules/OVSDriver/module/src/ovs_driver_int.h
@@ -100,6 +100,9 @@
 #define VLAN_VID(tci) ((tci) & 0xfff)
 #define VLAN_PCP(tci) ((tci) >> 13)
 
+/* Same as VLAN_TCI above except the vid includes the CFI bit */
+#define VLAN_TCI_WITH_CFI(vid, pcp) ( (((pcp) & 0x7) << 13) | ((vid) & 0x1fff) )
+
 
 /* Internal datastructures */
 


### PR DESCRIPTION
Reviewer: @poolakiran

Please read section A.2.3.7 of the OpenFlow 1.3.1 spec while reviewing this
change.

I'll also send the relevant OFTests out for review.
