### PR TITLE
OVSDriver: check for zero ttl when processing OF_ACTION_NICIRA_DEC_TTL

### DIFF
--- a/Modules/OVSDriver/module/src/translate_actions.c
+++ b/Modules/OVSDriver/module/src/translate_actions.c
@@ -343,7 +343,8 @@ ind_ovs_translate_actions(const struct ind_ovs_parsed_key *pkey,
             /* Special cased because it can drop the packet */
             if (ATTR_BITMAP_TEST(ctx.current_key.populated, OVS_KEY_ATTR_IPV4)) {
                 ATTR_BITMAP_SET(ctx.modified_attrs, OVS_KEY_ATTR_IPV4);
-                if (--ctx.current_key.ipv4.ipv4_ttl == 0) {
+                if (ctx.current_key.ipv4.ipv4_ttl == 0
+                    || --ctx.current_key.ipv4.ipv4_ttl == 0) {
                     goto finish;
                 }
             }


### PR DESCRIPTION
Reviewer: @poolakiran

This could previously underflow if we received a packet with ttl == 0.

Partial fix for XE-51.
