### PR TITLE
OVSDriver: workaround kernel errno bug

### DIFF
--- a/targets/ivs-ctl/main.c
+++ b/targets/ivs-ctl/main.c
@@ -271,7 +271,7 @@ del_port(const char *datapath, const char *interface)
      * returned random values on success. Work around this by assuming the
      * operation was successful if the kernel returned an invalid errno.
      */
-    if (err > 0 || err < -1024) {
+    if (err > 0 || err < -4095) {
         err = 0;
     }
 


### PR DESCRIPTION
Reviewer: @poolakiran

Older versions of the openvswitch kernel module had a bug where they returned 
garbage errno values in case of success.

This change ports the workaround already in ivs-ctl to the OVSDriver transact 
utility method. It also increases the range of valid errnos based on
MAX_ERRNO in the kernel source.
