### PR TITLE
OVSDriver: update CFR between tables for set-field actions

### DIFF
--- a/Modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/Modules/OVSDriver/module/src/ovs_driver_int.h
@@ -108,6 +108,10 @@
 /* Same as VLAN_TCI above except the vid includes the CFI bit */
 #define VLAN_TCI_WITH_CFI(vid, pcp) ( (((pcp) & 0x7) << 13) | ((vid) & 0x1fff) )
 
+#define IP_DSCP_MASK 0xfc
+#define IP_ECN_MASK 0x03
+#define IPV6_FLABEL_MASK 0x000fffff
+
 
 /* Internal datastructures */
 

--- a/Modules/OVSDriver/module/src/translate_actions.c
+++ b/Modules/OVSDriver/module/src/translate_actions.c
@@ -215,10 +215,6 @@ ind_ovs_action_set_ipv4_src(struct nlattr *attr, struct translate_context *ctx)
     }
 }
 
-#define IP_DSCP_MASK 0xfc
-#define IP_ECN_MASK 0x03
-#define IPV6_FLABEL_MASK 0x000fffff
-
 static void
 ind_ovs_action_set_ip_dscp(struct nlattr *attr, struct translate_context *ctx)
 {


### PR DESCRIPTION
Reviewer: @poolakiran

An apply-actions instruction should influence later matches.
