### PR TITLE
OVSDriver: fix pktin match issues for OF 1.3

### DIFF
--- a/Modules/OVSDriver/module/src/translate_match.c
+++ b/Modules/OVSDriver/module/src/translate_match.c
@@ -90,7 +90,7 @@ ind_ovs_key_to_match(const struct ind_ovs_parsed_key *pkey,
     memset(match, 0, sizeof(*match));
 
     /* We only populate the masks for this OF version */
-    match->version = OF_VERSION_1_0;
+    match->version = ind_ovs_version;
 
     of_match_fields_t *fields = &match->fields;
 
@@ -117,8 +117,15 @@ ind_ovs_key_to_match(const struct ind_ovs_parsed_key *pkey,
     if (ATTR_BITMAP_TEST(pkey->populated, OVS_KEY_ATTR_VLAN)) {
         fields->vlan_vid = VLAN_VID(ntohs(pkey->vlan));
         fields->vlan_pcp = VLAN_PCP(ntohs(pkey->vlan));
+        if (ind_ovs_version == OF_VERSION_1_3) {
+            fields->vlan_vid |= VLAN_CFI_BIT;
+        }
     } else {
-        fields->vlan_vid = -1;
+        if (ind_ovs_version == OF_VERSION_1_0) {
+            fields->vlan_vid = -1;
+        } else {
+            fields->vlan_vid = 0;
+        }
         fields->vlan_pcp = 0;
     }
     OF_MATCH_MASK_VLAN_VID_EXACT_SET(match);
@@ -149,12 +156,14 @@ ind_ovs_key_to_match(const struct ind_ovs_parsed_key *pkey,
         memcpy(&fields->arp_tha, pkey->arp.arp_tha, OF_MAC_ADDR_BYTES);
 
         /* Special case ARP for OF 1.0 */
-        fields->ipv4_src = ntohl(pkey->arp.arp_sip);
-        fields->ipv4_dst = ntohl(pkey->arp.arp_tip);
-        fields->ip_proto = ntohs(pkey->arp.arp_op) & 0xFF;
-        OF_MATCH_MASK_IPV4_SRC_EXACT_SET(match);
-        OF_MATCH_MASK_IPV4_DST_EXACT_SET(match);
-        OF_MATCH_MASK_IP_PROTO_EXACT_SET(match);
+        if (ind_ovs_version == OF_VERSION_1_0) {
+            fields->ipv4_src = ntohl(pkey->arp.arp_sip);
+            fields->ipv4_dst = ntohl(pkey->arp.arp_tip);
+            fields->ip_proto = ntohs(pkey->arp.arp_op) & 0xFF;
+            OF_MATCH_MASK_IPV4_SRC_EXACT_SET(match);
+            OF_MATCH_MASK_IPV4_DST_EXACT_SET(match);
+            OF_MATCH_MASK_IP_PROTO_EXACT_SET(match);
+        }
     }
 
     if (ATTR_BITMAP_TEST(pkey->populated, OVS_KEY_ATTR_TCP)) {
@@ -169,10 +178,12 @@ ind_ovs_key_to_match(const struct ind_ovs_parsed_key *pkey,
         fields->udp_src = ntohs(pkey->udp.udp_src);
 
         /* Special case UDP for OF 1.0 */
-        fields->tcp_dst = ntohs(pkey->udp.udp_dst);
-        fields->tcp_src = ntohs(pkey->udp.udp_src);
-        OF_MATCH_MASK_TCP_DST_EXACT_SET(match);
-        OF_MATCH_MASK_TCP_SRC_EXACT_SET(match);
+        if (ind_ovs_version == OF_VERSION_1_0) {
+            fields->tcp_dst = ntohs(pkey->udp.udp_dst);
+            fields->tcp_src = ntohs(pkey->udp.udp_src);
+            OF_MATCH_MASK_TCP_DST_EXACT_SET(match);
+            OF_MATCH_MASK_TCP_SRC_EXACT_SET(match);
+        }
     }
 
     if (ATTR_BITMAP_TEST(pkey->populated, OVS_KEY_ATTR_ICMP)) {
@@ -180,10 +191,12 @@ ind_ovs_key_to_match(const struct ind_ovs_parsed_key *pkey,
         fields->icmpv4_code = pkey->icmp.icmp_code;
 
         /* Special case ICMP for OF 1.0 */
-        fields->tcp_dst = pkey->icmp.icmp_code;
-        fields->tcp_src = pkey->icmp.icmp_type;
-        OF_MATCH_MASK_TCP_DST_EXACT_SET(match);
-        OF_MATCH_MASK_TCP_SRC_EXACT_SET(match);
+        if (ind_ovs_version == OF_VERSION_1_0) {
+            fields->tcp_dst = pkey->icmp.icmp_code;
+            fields->tcp_src = pkey->icmp.icmp_type;
+            OF_MATCH_MASK_TCP_DST_EXACT_SET(match);
+            OF_MATCH_MASK_TCP_SRC_EXACT_SET(match);
+        }
     }
 
     if (ATTR_BITMAP_TEST(pkey->populated, OVS_KEY_ATTR_ICMPV6)) {


### PR DESCRIPTION
Reviewer: @poolakiran

The VLAN VID representation changed between OF 1.0 and 1.3. Also need to omit 
the tcp_src OXM for UDP/etc packets since 1.2+ gives them their own OXMs.
