### PR TITLE
OVSDriver: limit maximum number of flows across all tables (XE-62)

### DIFF
--- a/modules/OVSDriver/module/inc/OVSDriver/ovsdriver.h
+++ b/modules/OVSDriver/module/inc/OVSDriver/ovsdriver.h
@@ -23,7 +23,7 @@
 struct xbuf;
 struct ind_ovs_cfr;
 
-indigo_error_t ind_ovs_init(const char *datapath_name);
+indigo_error_t ind_ovs_init(const char *datapath_name, uint32_t max_flows);
 void ind_ovs_finish(void);
 
 indigo_error_t ind_ovs_tunnel_init(void);

--- a/modules/OVSDriver/module/src/ovs_driver.c
+++ b/modules/OVSDriver/module/src/ovs_driver.c
@@ -47,6 +47,7 @@ int ovs_datapath_family, ovs_packet_family, ovs_vport_family, ovs_flow_family;
 bool ind_ovs_benchmark_mode = false;
 uint32_t ind_ovs_salt;
 int ind_ovs_version = OF_VERSION_1_0;
+uint32_t ind_ovs_max_flows;
 
 static int
 ind_ovs_create_datapath(const char *name)
@@ -145,7 +146,7 @@ indigo_fwd_expiration_enable_get(int *is_enabled)
 }
 
 indigo_error_t
-ind_ovs_init(const char *datapath_name)
+ind_ovs_init(const char *datapath_name, uint32_t max_flows)
 {
     int ret;
 
@@ -154,6 +155,8 @@ ind_ovs_init(const char *datapath_name)
         LOG_WARN("Benchmark mode enabled.");
         ind_ovs_benchmark_mode = true;
     }
+
+    ind_ovs_max_flows = max_flows;
 
     ind_ovs_salt = get_entropy();
 

--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -422,4 +422,9 @@ struct ind_ovs_table ind_ovs_tables[IND_OVS_NUM_TABLES];
  */
 extern struct ind_ovs_pktin_suppression_cfg ind_ovs_pktin_suppression_cfg;
 
+/*
+ * Maximum number of flows allowed across all flowtables.
+ */
+extern uint32_t ind_ovs_max_flows;
+
 #endif

--- a/targets/ivs/main.c
+++ b/targets/ivs/main.c
@@ -105,6 +105,7 @@ static char *datapath_name = "indigo";
 static char *config_filename = NULL;
 static char *openflow_version = NULL;
 static char *pipeline = NULL;
+static uint32_t max_flows = 262144;
 
 static int
 parse_controller(const char *str,
@@ -261,8 +262,9 @@ parse_options(int argc, char **argv)
             break;
 
         case OPT_MAX_FLOWS:
-            core_cfg.max_flowtable_entries = strtoll(optarg, NULL, 0);
-            AIM_LOG_MSG("Setting max flows to %d", core_cfg.max_flowtable_entries);
+            max_flows = strtoll(optarg, NULL, 0);
+            core_cfg.max_flowtable_entries = max_flows;
+            AIM_LOG_MSG("Setting max flows to %d", max_flows);
             break;
 
         case OPT_PIPELINE:
@@ -397,7 +399,7 @@ aim_main(int argc, char* argv[])
         return 1;
     }
 
-    if (ind_ovs_init(datapath_name) < 0) {
+    if (ind_ovs_init(datapath_name, max_flows) < 0) {
         AIM_LOG_FATAL("Failed to initialize OVSDriver module");
         return 1;
     }


### PR DESCRIPTION
Reviewer: @wilmo119

Reusing the old --max-flows command line option.
