### PR TITLE
add check_nw_ttl action

### DIFF
--- a/modules/ivs/module/inc/ivs/actions.h
+++ b/modules/ivs/module/inc/ivs/actions.h
@@ -65,6 +65,7 @@ enum {
     IND_OVS_ACTION_SET_L3_SRC_CLASS_ID,     /* uint32_t */
     IND_OVS_ACTION_SET_L3_DST_CLASS_ID,     /* uint32_t */
     IND_OVS_ACTION_SET_GLOBAL_VRF_ALLOWED,  /* uint8_t */
+    IND_OVS_ACTION_CHECK_NW_TTL,
 };
 
 #endif


### PR DESCRIPTION
Reviewer: @poolakiran

This action can be used by the pipeline to send a packet-in and drop if the TTL would be invalid after a decrement. This is useful in case we want to skip other lookups and rewrites that happen before the real dec_nw_ttl action.
