### PR TITLE
support OFPPC_PORT_DOWN

### DIFF
--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -111,6 +111,7 @@ struct ind_ovs_port {
     of_mac_addr_t mac_addr;
     unsigned no_packet_in : 1;
     unsigned no_flood : 1;
+    unsigned admin_down : 1;
     uint32_t num_kflows; /* Number of kflows with this in_port */
     struct nl_sock *notify_socket; /* Netlink socket for upcalls */
     aim_ratelimiter_t upcall_log_limiter;


### PR DESCRIPTION
Reviewer: @harshsin

See "man 7 netdevice". OFPPC_PORT_DOWN is synchronized with !IFF_UP, and
OFPPS_LINK_DOWN is !IFF_RUNNING.
