### PR TITLE
oftest.py: disable ratelimiters

### DIFF
--- a/build/oftest.py
+++ b/build/oftest.py
@@ -75,6 +75,9 @@ import select
 import platform
 import logging
 
+# Prevent ratelimiters from causing test failures
+os.environ['INDIGO_BENCHMARK'] = '1'
+
 ###############################################################################
 #
 # Helpers


### PR DESCRIPTION
Reviewer: trivial

The new latency.PktinLatency test was failing because it sends many packet-in 
messages on a single port, triggering a ratelimiter.
