### PR TITLE
OVSDriver: zero unpopulated fields of parsed key

### DIFF
--- a/modules/OVSDriver/module/src/kflow.c
+++ b/modules/OVSDriver/module/src/kflow.c
@@ -71,7 +71,6 @@ ind_ovs_kflow_add(const struct nlattr *key)
     }
 
     struct ind_ovs_parsed_key pkey;
-    memset(&pkey, 0, sizeof(pkey));
     ind_ovs_parse_key((struct nlattr *)key, &pkey);
 
     struct pipeline_result *result = &ind_ovs_kflow_pipeline_result;

--- a/modules/OVSDriver/module/src/translate_match.c
+++ b/modules/OVSDriver/module/src/translate_match.c
@@ -71,6 +71,7 @@ ind_ovs_parse_key__(struct nlattr *key, struct ind_ovs_parsed_key *pkey)
 void
 ind_ovs_parse_key(struct nlattr *key, struct ind_ovs_parsed_key *pkey)
 {
+    memset(pkey, 0, sizeof(*pkey));
     pkey->populated = 0;
     pkey->in_port = -1;
     pkey->tunnel.id = 0;

--- a/modules/OVSDriver/module/src/upcall.c
+++ b/modules/OVSDriver/module/src/upcall.c
@@ -248,7 +248,6 @@ ind_ovs_handle_packet_miss(struct ind_ovs_upcall_thread *thread,
     assert(key && packet);
 
     struct ind_ovs_parsed_key pkey;
-    memset(&pkey, 0, sizeof(pkey));
     ind_ovs_parse_key(key, &pkey);
 
     struct pipeline_result *result = &thread->result;


### PR DESCRIPTION
Reviewer: trivial

The select group code hashes the entire key, not just the populated fields.
