### PR TITLE
add environment variable to disable kflow installation

### DIFF
--- a/modules/OVSDriver/module/src/ovs_driver.c
+++ b/modules/OVSDriver/module/src/ovs_driver.c
@@ -45,6 +45,7 @@ int ind_ovs_dp_ifindex = 0;
 struct nl_sock *ind_ovs_socket;
 int ovs_datapath_family, ovs_packet_family, ovs_vport_family, ovs_flow_family;
 bool ind_ovs_benchmark_mode = false;
+bool ind_ovs_disable_kflows = false;
 uint32_t ind_ovs_salt;
 uint32_t ind_ovs_max_flows;
 
@@ -148,11 +149,18 @@ indigo_error_t
 ind_ovs_init(const char *datapath_name, uint32_t max_flows)
 {
     int ret;
+    char *env_str;
 
-    char *bm_str = getenv("INDIGO_BENCHMARK");
-    if (bm_str != NULL && atoi(bm_str) == 1) {
+    env_str = getenv("INDIGO_BENCHMARK");
+    if (env_str != NULL && atoi(env_str) == 1) {
         LOG_WARN("Benchmark mode enabled.");
         ind_ovs_benchmark_mode = true;
+    }
+
+    env_str = getenv("IVS_DISABLE_KFLOWS");
+    if (env_str != NULL && atoi(env_str) == 1) {
+        LOG_WARN("Kernel flow installation disabled.");
+        ind_ovs_disable_kflows = true;
     }
 
     ind_ovs_max_flows = max_flows;

--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -330,6 +330,15 @@ extern struct ind_ovs_port *ind_ovs_ports[IND_OVS_MAX_PORTS];
 extern bool ind_ovs_benchmark_mode;
 
 /*
+ * When debugging the controller (and using verbose logging on the switch)
+ * it's often helpful to see the pipeline logs for every packet. This flag
+ * prevents IVS from installing kernel flows, so every packet will be
+ * received as an upcall.
+ * Set it with the environment variable IVS_DISABLE_KFLOWS=1.
+ */
+extern bool ind_ovs_disable_kflows;
+
+/*
  * Random number used to prevent guests from deliberately causing hash
  * collisions.
  */

--- a/modules/OVSDriver/module/src/upcall.c
+++ b/modules/OVSDriver/module/src/upcall.c
@@ -307,7 +307,7 @@ ind_ovs_handle_packet_miss(struct ind_ovs_upcall_thread *thread,
     }
 
     /* See the comment for ind_ovs_upcall_seen_key. */
-    if (ind_ovs_upcall_seen_key(thread, key)) {
+    if (!ind_ovs_disable_kflows && ind_ovs_upcall_seen_key(thread, key)) {
         /* Create a kflow with the given key and actions. */
         ind_ovs_bh_request_kflow(key);
     }


### PR DESCRIPTION
Reviewer: trivial

When debugging the controller (and using verbose logging on the switch) it's
often helpful to see the pipeline logs for every packet. This flag prevents
IVS from installing kernel flows, so every packet will be received as an
upcall.

Set it with the environment variable IVS_DISABLE_KFLOWS=1.
