### PR TITLE
ivs: tune malloc trim threshold

### DIFF
--- a/targets/ivs/main.c
+++ b/targets/ivs/main.c
@@ -49,6 +49,7 @@
 #include <icmpa/icmpa.h>
 #include <pipeline/pipeline.h>
 #include <dhcpra/dhcpra.h>
+#include <malloc.h>
 
 #define AIM_LOG_MODULE_NAME ivs
 #include <AIM/aim_log.h>


### PR DESCRIPTION
Reviewer: trivial

When processing a batch of messages in a single tick of the event loop, we 
allocate a 64 KB block per message and then free them all at once after
writing to the socket. Looking at the strace, I noticed we were doing a brk()
for every message allocation. When freeing the messages we did another brk()
which released all the memory. The allocator has a limit on the amount of free
memory it will keep in the process before it starts releasing it back to the
OS. Our malloc churn is larger than the 128 KB default, so this change adjusts
the trim threshold to 2 MB.

This improves performance in my echo benchmark by 150%.
