### PR TITLE
allow pipelines to set the metadata OXM in packet-in messages

### DIFF
--- a/modules/OVSDriver/module/src/bh.c
+++ b/modules/OVSDriver/module/src/bh.c
@@ -43,7 +43,8 @@ struct ind_ovs_bh_request {
 
     /* Only for packet-in */
     uint32_t in_port;
-    int reason;
+    uint8_t reason;
+    uint64_t metadata;
 
     /* Netlink attrs follow */
     struct nlattr attr_head[0];
@@ -78,7 +79,7 @@ ind_ovs_bh_request_kflow(struct nlattr *key)
 }
 
 void
-ind_ovs_bh_request_pktin(uint32_t in_port, struct nlattr *packet, struct nlattr *key, int reason)
+ind_ovs_bh_request_pktin(uint32_t in_port, struct nlattr *packet, struct nlattr *key, uint8_t reason, uint64_t metadata)
 {
     int packet_size = nla_total_size(nla_len(packet));
     int key_size = nla_total_size(nla_len(key));
@@ -88,6 +89,7 @@ ind_ovs_bh_request_pktin(uint32_t in_port, struct nlattr *packet, struct nlattr 
     req->len = packet_size + key_size;
     req->in_port = in_port;
     req->reason = reason;
+    req->metadata = metadata;
     memcpy(req->attr_head, packet, packet_size);
     memcpy(((void *)(req->attr_head)) + packet_size, key, key_size);
 
@@ -155,7 +157,7 @@ ind_ovs_bh_run()
             struct ind_ovs_parsed_key pkey;
             ind_ovs_parse_key(key, &pkey);
 
-            ind_fwd_pkt_in(req->in_port, nla_data(packet), nla_len(packet), req->reason, &pkey);
+            ind_fwd_pkt_in(req->in_port, nla_data(packet), nla_len(packet), req->reason, req->metadata, &pkey);
         } else {
             abort();
         }

--- a/modules/OVSDriver/module/src/fwd.c
+++ b/modules/OVSDriver/module/src/fwd.c
@@ -508,7 +508,7 @@ indigo_fwd_table_stats_get(of_table_stats_request_t *table_stats_request,
 
 indigo_error_t
 ind_fwd_pkt_in(of_port_no_t in_port,
-               uint8_t *data, unsigned int len, unsigned reason,
+               uint8_t *data, unsigned int len, uint8_t reason, uint64_t metadata,
                struct ind_ovs_parsed_key *pkey)
 {
     LOG_TRACE("Sending packet-in");
@@ -533,6 +533,8 @@ ind_fwd_pkt_in(of_port_no_t in_port,
 
     of_match_t match;
     ind_ovs_key_to_match(pkey, ctrlr_of_version, &match);
+    match.fields.metadata = metadata;
+    OF_MATCH_MASK_METADATA_EXACT_SET(&match);
 
     if (ind_ovs_pktin_suppression_cfg.enabled && reason == OF_PACKET_IN_REASON_NO_MATCH) {
         LOG_TRACE("installing pktin suppression flow");

--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -215,7 +215,7 @@ void ind_ovs_key_to_match(const struct ind_ovs_parsed_key *pkey, of_version_t ve
 /* Internal interfaces to the forwarding module */
 indigo_error_t ind_ovs_fwd_init(void);
 void ind_ovs_fwd_finish(void);
-indigo_error_t ind_fwd_pkt_in(of_port_no_t of_port_num, uint8_t *data, unsigned int len, unsigned reason, struct ind_ovs_parsed_key *pkey);
+indigo_error_t ind_fwd_pkt_in(of_port_no_t of_port_num, uint8_t *data, unsigned int len, uint8_t reason, uint64_t metadata, struct ind_ovs_parsed_key *pkey);
 struct ind_ovs_flow_effects *ind_ovs_fwd_pipeline_lookup(int table_id, struct ind_ovs_cfr *cfr, struct xbuf *stats);
 
 /*
@@ -259,7 +259,7 @@ void ind_ovs_upcall_quiesce(struct ind_ovs_port *port);
 /* Interface of the bottom-half submodule */
 void ind_ovs_bh_init();
 void ind_ovs_bh_request_kflow(struct nlattr *key);
-void ind_ovs_bh_request_pktin(uint32_t in_port, struct nlattr *packet, struct nlattr *key, int reason);
+void ind_ovs_bh_request_pktin(uint32_t in_port, struct nlattr *packet, struct nlattr *key, uint8_t reason, uint64_t metadata);
 
 /* Interface of the multicast submodule */
 void ind_ovs_multicast_init(void);

--- a/modules/OVSDriver/module/src/translate_actions.c
+++ b/modules/OVSDriver/module/src/translate_actions.c
@@ -101,16 +101,16 @@ OVS_TUNNEL_KEY_FIELDS
     ctx->modified_attrs = 0;
 }
 
-/* Send the packet back to an upcall thread with the given reason as userdata */
+/* Send the packet back to an upcall thread with the given userdata */
 static void
-pktin(uint8_t reason, struct translate_context *ctx)
+pktin(uint64_t userdata, struct translate_context *ctx)
 {
     uint32_t ingress_port_no = ctx->current_key.in_port;
     ind_ovs_commit_set_field_actions(ctx);
     struct nlattr *action_attr = nla_nest_start(ctx->msg, OVS_ACTION_ATTR_USERSPACE);
     struct nl_sock *sk = ind_ovs_ports[ingress_port_no]->notify_socket;
     nla_put_u32(ctx->msg, OVS_USERSPACE_ATTR_PID, nl_socket_get_local_port(sk));
-    nla_put_u64(ctx->msg, OVS_USERSPACE_ATTR_USERDATA, reason);
+    nla_put_u64(ctx->msg, OVS_USERSPACE_ATTR_USERDATA, userdata);
     nla_nest_end(ctx->msg, action_attr);
 }
 
@@ -128,8 +128,8 @@ ind_ovs_action_output(struct nlattr *attr, struct translate_context *ctx)
 static void
 ind_ovs_action_controller(struct nlattr *attr, struct translate_context *ctx)
 {
-    uint8_t reason = *XBUF_PAYLOAD(attr, uint8_t);
-    pktin(reason, ctx);
+    uint64_t userdata = *XBUF_PAYLOAD(attr, uint64_t);
+    pktin(userdata, ctx);
 }
 
 static void
@@ -584,7 +584,8 @@ ind_ovs_translate_openflow_actions(of_list_action_t *actions, struct xbuf *xbuf,
                 case OF_PORT_DEST_CONTROLLER: {
                     uint8_t reason = table_miss ? OF_PACKET_IN_REASON_NO_MATCH :
                                                   OF_PACKET_IN_REASON_ACTION;
-                    xbuf_append_attr(xbuf, IND_OVS_ACTION_CONTROLLER, &reason, sizeof(reason));
+                    uint64_t userdata = IVS_PKTIN_USERDATA(reason, 0);
+                    xbuf_append_attr(xbuf, IND_OVS_ACTION_CONTROLLER, &userdata, sizeof(userdata));
                     break;
                 }
                 case OF_PORT_DEST_FLOOD:

--- a/modules/OVSDriver/module/src/upcall.c
+++ b/modules/OVSDriver/module/src/upcall.c
@@ -87,7 +87,7 @@ static void ind_ovs_handle_port_upcalls(struct ind_ovs_upcall_thread *thread, st
 static void ind_ovs_handle_one_upcall(struct ind_ovs_upcall_thread *thread, struct ind_ovs_port *port, struct nl_msg *msg);
 static void ind_ovs_handle_packet_miss(struct ind_ovs_upcall_thread *thread, struct ind_ovs_port *port, struct nl_msg *msg, struct nlattr **attrs);
 static void ind_ovs_handle_packet_action(struct ind_ovs_upcall_thread *thread, struct ind_ovs_port *port, struct nl_msg *msg, struct nlattr **attrs);
-static void ind_ovs_upcall_request_pktin(uint32_t port_no, struct ind_ovs_port *port, struct nlattr *packet, struct nlattr *key, int reason);
+static void ind_ovs_upcall_request_pktin(uint32_t port_no, struct ind_ovs_port *port, struct nlattr *packet, struct nlattr *key, uint8_t reason, uint64_t metadata);
 static bool ind_ovs_upcall_seen_key(struct ind_ovs_upcall_thread *thread, struct nlattr *key);
 static void ind_ovs_upcall_rearm(struct ind_ovs_port *port);
 
@@ -279,8 +279,10 @@ ind_ovs_handle_packet_miss(struct ind_ovs_upcall_thread *thread,
              * to be received as another upcall, so request a pktin
              * directly here.
              */
-            uint8_t reason = *XBUF_PAYLOAD(first_action, uint8_t);
-            ind_ovs_upcall_request_pktin(pkey.in_port, port, packet, key, reason);
+            uint64_t userdata = *XBUF_PAYLOAD(first_action, uint64_t);
+            ind_ovs_upcall_request_pktin(pkey.in_port, port, packet, key,
+                                         IVS_PKTIN_REASON(userdata),
+                                         IVS_PKTIN_METADATA(userdata));
             return;
         }
     }
@@ -320,24 +322,26 @@ ind_ovs_handle_packet_action(struct ind_ovs_upcall_thread *thread,
 {
     struct nlattr *key = attrs[OVS_PACKET_ATTR_KEY];
     struct nlattr *packet = attrs[OVS_PACKET_ATTR_PACKET];
-    struct nlattr *userdata = attrs[OVS_PACKET_ATTR_USERDATA];
-    assert(key && packet && userdata);
+    struct nlattr *userdata_nla = attrs[OVS_PACKET_ATTR_USERDATA];
+    assert(key && packet && userdata_nla);
 
     struct ind_ovs_parsed_key pkey;
     ind_ovs_parse_key(key, &pkey);
 
-    uint8_t reason = (uint8_t)nla_get_u64(userdata);
+    uint64_t userdata = nla_get_u64(userdata_nla);
 
     /* Send packet-in to controller */
-    ind_ovs_upcall_request_pktin(pkey.in_port, port, packet, key, reason);
+    ind_ovs_upcall_request_pktin(pkey.in_port, port, packet, key,
+                                 IVS_PKTIN_REASON(userdata),
+                                 IVS_PKTIN_METADATA(userdata));
 }
 
 static void
 ind_ovs_upcall_request_pktin(uint32_t port_no, struct ind_ovs_port *port,
-                             struct nlattr *packet, struct nlattr *key, int reason)
+                             struct nlattr *packet, struct nlattr *key, uint8_t reason, uint64_t metadata)
 {
     if (ind_ovs_benchmark_mode || aim_ratelimiter_limit(&port->pktin_limiter, monotonic_us()) == 0) {
-        ind_ovs_bh_request_pktin(port_no, packet, key, reason);
+        ind_ovs_bh_request_pktin(port_no, packet, key, reason, metadata);
     } else {
         if (aim_ratelimiter_limit(&port->upcall_log_limiter, monotonic_us()) == 0) {
             LOG_WARN("rate limiting packet-ins from port %s", port->ifname);

--- a/modules/ivs/module/inc/ivs/actions.h
+++ b/modules/ivs/module/inc/ivs/actions.h
@@ -30,7 +30,7 @@
 
 enum {
     IND_OVS_ACTION_OUTPUT, /* of_port_no_t */
-    IND_OVS_ACTION_CONTROLLER, /* uint8_t reason */
+    IND_OVS_ACTION_CONTROLLER, /* uint64_t userdata (reason in bottom 8 bits, metadata in top 56 bits) */
     IND_OVS_ACTION_FLOOD,
     IND_OVS_ACTION_ALL,
     IND_OVS_ACTION_LOCAL,

--- a/modules/ivs/module/inc/ivs/ivs.h
+++ b/modules/ivs/module/inc/ivs/ivs.h
@@ -54,6 +54,10 @@
 /* Use instead of assert for cases we should eventually handle. */
 #define NYI(x) assert(!(x))
 
+#define IVS_PKTIN_USERDATA(reason, metadata) (reason) | ((uint64_t)(metadata) << 8)
+#define IVS_PKTIN_REASON(userdata) (userdata) & 0xff
+#define IVS_PKTIN_METADATA(userdata) (userdata) >> 8
+
 /*
  * Derived from a flow's actions/instructions.
  */

--- a/modules/pipeline_standard/module/src/pipeline_standard.c
+++ b/modules/pipeline_standard/module/src/pipeline_standard.c
@@ -66,8 +66,8 @@ pipeline_standard_process(struct ind_ovs_parsed_key *key,
             ind_ovs_fwd_pipeline_lookup(table_id, &cfr, &result->stats);
         if (effects == NULL) {
             if (openflow_version < OF_VERSION_1_3) {
-                uint8_t reason = OF_PACKET_IN_REASON_NO_MATCH;
-                xbuf_append_attr(&result->actions, IND_OVS_ACTION_CONTROLLER, &reason, sizeof(reason));
+                uint64_t userdata = IVS_PKTIN_USERDATA(OF_PACKET_IN_REASON_NO_MATCH, 0);
+                xbuf_append_attr(&result->actions, IND_OVS_ACTION_CONTROLLER, &userdata, sizeof(userdata));
             }
             break;
         }


### PR DESCRIPTION
Reviewer: @poolakiran

Only 56 bits of metadata are supported because the packet-in reason takes 8
bits and the userdata nlattr (in old kernels) is only 64 bits.

This doesn't implement the full metadata matching and setting defined by OF
1.3. That will be possible after I do some refactoring of the action
translation code.
