### PR TITLE
OVSDriver: fix compilation on Ubuntu 14.04

### DIFF
--- a/modules/OVSDriver/module/src/vport.c
+++ b/modules/OVSDriver/module/src/vport.c
@@ -673,7 +673,7 @@ link_change_cb(struct nl_cache *cache,
      * Ignore additions/deletions, already handled by
      * ind_ovs_handle_vport_multicast.
      */
-    if (action != NL_ACT_CHANGE) {
+    if (action != 5 /* NL_ACT_CHANGE */) {
         return;
     }
 


### PR DESCRIPTION
Reviewer: trivial

The libnl library mistakenly removed this constant from the headers. This is 
fixed in later versions of libnl.
