### PR TITLE
Implement of_bsn_lua_command_request message

### DIFF
--- a/modules/pipeline_lua/module/src/allocator.c
+++ b/modules/pipeline_lua/module/src/allocator.c
@@ -1,0 +1,78 @@
+/****************************************************************
+ *
+ *        Copyright 2015, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+/*
+ * Bump allocator
+ *
+ * This allocator is used for safety, not speed. We don't want to give
+ * Lua code pointers to the normal heap because it could save them
+ * and use them later when they refer to a different object.
+ *
+ * Instead, we dedicate memory for communication with Lua. Even if
+ * Lua code tries to access this memory after it's been freed, it
+ * won't be able to read or write datastructures that it doesn't
+ * already own. The corollary is that C code can't trust anything
+ * it reads from this memory.
+ *
+ * The lifetime of these allocations is limited to a single "event",
+ * whether it's a gentable operation, upcall processing, etc. This
+ * assumption enables us to reset the heap all at once instead of
+ * freeing allocations individually.
+ */
+
+#include <stdlib.h>
+#include "pipeline_lua_int.h"
+
+#define AIM_LOG_MODULE_NAME pipeline_lua
+#include <AIM/aim_log.h>
+
+/*
+ * We only expect to need 2*64K for the worst case of the
+ * bsn_lua_command_request message.
+ */
+#define ALLOCATOR_SIZE (1024*1024)
+
+static char allocator_heap[ALLOCATOR_SIZE];
+static uint32_t allocator_offset;
+
+void *
+pipeline_lua_allocator_alloc(uint32_t size)
+{
+    if (size > ALLOCATOR_SIZE || allocator_offset + size > ALLOCATOR_SIZE) {
+        AIM_DIE("Exceeded Lua allocator maximum size");
+    }
+
+    void *ptr = allocator_heap + allocator_offset;
+    allocator_offset += size;
+    return ptr;
+}
+
+void *
+pipeline_lua_allocator_dup(void *src, uint32_t size)
+{
+    void *dst = pipeline_lua_allocator_alloc(size);
+    memcpy(dst, src, size);
+    return dst;
+}
+
+void
+pipeline_lua_allocator_reset(void)
+{
+    allocator_offset = 0;
+}

--- a/modules/pipeline_lua/module/src/base.lua
+++ b/modules/pipeline_lua/module/src/base.lua
@@ -94,9 +94,11 @@ ffi.cdef[[
 void pipeline_lua_log(const char *str);
 ]]
 
-function sandbox.log(...)
+function log(...)
     C.pipeline_lua_log(string.format(...))
 end
+
+sandbox.log = log
 
 ---- Context
 

--- a/modules/pipeline_lua/module/src/base.lua
+++ b/modules/pipeline_lua/module/src/base.lua
@@ -82,6 +82,17 @@ function process()
     sandbox.ingress()
 end
 
+-- To be overridden by uploaded code
+function sandbox.command(reader, writer) end
+
+-- Entrypoint for command request
+function command(request_data, request_data_length, reply_data, reply_data_length)
+    local reader = Reader.new(request_data, request_data_length)
+    local writer = Writer.new(reply_data, reply_data_length)
+    sandbox.command(reader, writer)
+    return writer.offset()
+end
+
 function sandbox.require(name)
     return sandbox[name]
 end

--- a/modules/pipeline_lua/module/src/binary.lua
+++ b/modules/pipeline_lua/module/src/binary.lua
@@ -1,0 +1,133 @@
+--        Copyright 2015, Big Switch Networks, Inc.
+--
+-- Licensed under the Eclipse Public License, Version 1.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License. You may obtain a copy of the License at
+--
+--        http://www.eclipse.org/legal/epl-v10.html
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+-- either express or implied. See the License for the specific
+-- language governing permissions and limitations under the
+-- License.
+
+local bit = require("bit")
+local ffi = require("ffi")
+local rshift = bit.rshift
+local ntohl = ffi.abi("le") and bit.bswap or function(x) return x end
+local ntohs = ffi.abi("le") and function(x) return rshift(ntohl(x), 16) end or function(x) return x end
+local P8 = ffi.typeof("uint8_t *")
+local P16 = ffi.typeof("uint16_t *")
+local P32 = ffi.typeof("uint32_t *")
+
+-- buf is a lightuserdata
+-- len is the maximum offset + 1
+-- offset is our current position
+Reader = {}
+Reader.new = function(buf, len, offset)
+    local self = {}
+    offset = offset or 0
+    buf = ffi.cast(P8, buf)
+
+    local function check_length(n)
+        assert(offset + n <= len)
+    end
+
+    self.u8 = function()
+        check_length(1)
+        local ret = buf[offset]
+        offset = offset + 1
+        return ret
+    end
+
+    self.u16 = function()
+        check_length(2)
+        local ptr = ffi.cast(P16, buf+offset)
+        local ret = ntohs(ptr[0])
+        offset = offset + 2
+        return ret
+    end
+
+    self.u32 = function()
+        check_length(4)
+        local ptr = ffi.cast(P32, buf+offset)
+        local ret = ntohl(ptr[0])
+        offset = offset + 4
+        return ret
+    end
+
+    self.blob = function(n)
+        check_length(n)
+        local ret = ffi.string(buf+offset, n)
+        offset = offset + n
+        return ret
+    end
+
+    self.skip = function(n)
+        assert(offset + n <= len)
+        offset = offset + n
+    end
+
+    self.is_empty = function()
+        return offset == len
+    end
+
+    self.slice = function(n)
+        assert(offset + n <= len)
+        r = Reader.new(buf, n, offset)
+        offset = offset + n
+        return r
+    end
+
+    self.offset = function()
+        return offset
+    end
+
+    return self
+end
+
+Writer = {}
+Writer.new = function(buf, len)
+    local self = {}
+    local offset = 0
+    buf = ffi.cast(P8, buf)
+
+    local function check_length(n)
+        assert(offset + n <= len)
+    end
+
+    self.u8 = function(x)
+        check_length(1)
+        buf[offset] = x
+        offset = offset + 1
+    end
+
+    self.u16 = function(x)
+        check_length(2)
+        local ptr = ffi.cast(P16, buf+offset)
+        ptr[0] = ntohs(x)
+        offset = offset + 2
+    end
+
+    self.u32 = function(x)
+        check_length(4)
+        local ptr = ffi.cast(P32, buf+offset)
+        ptr[0] = ntohl(x)
+        offset = offset + 4
+    end
+
+    self.blob = function(x)
+        local n = x:len()
+        check_length(n)
+        ffi.copy(buf+offset, x, n)
+        offset = offset + n
+    end
+
+    self.offset = function()
+        return offset
+    end
+
+    return self
+end

--- a/modules/pipeline_lua/module/src/builtin_lua.c
+++ b/modules/pipeline_lua/module/src/builtin_lua.c
@@ -23,7 +23,8 @@
  * load them into the VM they need to be specified here */
 #define BUILTIN_LUA \
     X(base) \
-    X(actions)
+    X(actions) \
+    X(binary)
 
 #define BUILTIN_LUA_START(name) _binary_ ## name ## _lua_start
 #define BUILTIN_LUA_END(name) _binary_ ## name ## _lua_end

--- a/modules/pipeline_lua/module/src/pipeline_lua_int.h
+++ b/modules/pipeline_lua/module/src/pipeline_lua_int.h
@@ -62,4 +62,8 @@ extern const char *pipeline_lua_field_names[];
 /* Terminated by name == NULL */
 extern const struct builtin_lua pipeline_lua_builtin_lua[];
 
+void *pipeline_lua_allocator_alloc(uint32_t size);
+void *pipeline_lua_allocator_dup(void *src, uint32_t size);
+void pipeline_lua_allocator_reset(void);
+
 #endif


### PR DESCRIPTION
Reviewer: @harshsin 

These changes implement the extensions defined in LOXI by https://github.com/floodlight/loxigen/pull/374.

My original usecase for these messages was OFTest. For testing APIs that aren't tied to an event like an upcall it's much simpler to activate the testcase using this message rather than sending some specially crafted packet or gentable entry. I now think it's also useful for querying small amounts of data from the switch or sending non-configuration commands like "reset counter".

The binary reader/writer and bump allocator will be used for tables and packet-ins in the future.