### PR TITLE
megaflow infrastructure

### DIFF
--- a/modules/OVSDriver/module/src/dump.c
+++ b/modules/OVSDriver/module/src/dump.c
@@ -243,6 +243,12 @@ ind_ovs_dump_flow_attr(const struct nlattr *attr)
         nest_end();
         break;
 
+    case OVS_FLOW_ATTR_MASK:
+        nest_start(OVS_FLOW_ATTR_MASK);
+        ind_ovs_dump_nested(attr, ind_ovs_dump_key_attr);
+        nest_end();
+        break;
+
     case OVS_FLOW_ATTR_ACTIONS:
         nest_start(OVS_FLOW_ATTR_ACTIONS);
         ind_ovs_dump_nested(attr, ind_ovs_dump_action_attr);

--- a/modules/OVSDriver/module/src/ovs_driver.c
+++ b/modules/OVSDriver/module/src/ovs_driver.c
@@ -47,6 +47,7 @@ struct nl_sock *ind_ovs_socket;
 int ovs_datapath_family, ovs_packet_family, ovs_vport_family, ovs_flow_family;
 bool ind_ovs_benchmark_mode = false;
 bool ind_ovs_disable_kflows = false;
+bool ind_ovs_disable_megaflows = false;
 uint32_t ind_ovs_salt;
 uint16_t ind_ovs_inband_vlan = VLAN_INVALID;
 
@@ -193,6 +194,12 @@ ind_ovs_init(const char *datapath_name)
     if (env_str != NULL && atoi(env_str) == 1) {
         LOG_WARN("Kernel flow installation disabled.");
         ind_ovs_disable_kflows = true;
+    }
+
+    env_str = getenv("IVS_DISABLE_MEGAFLOWS");
+    if (env_str != NULL && atoi(env_str) == 1) {
+        LOG_WARN("Megaflow installation disabled.");
+        ind_ovs_disable_megaflows = true;
     }
 
     ind_ovs_salt = get_entropy();

--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -134,6 +134,7 @@ struct ind_ovs_kflow {
     uint16_t num_stats_handles; /* size of stats_handles array */
     uint16_t actions_len; /* length of actions blob */
     uint64_t last_used; /* monotonic time in ms */
+    struct ind_ovs_parsed_key mask;
     void *actions; /* payload of actions nlattr */
     struct stats_handle *stats_handles;
     struct nlattr key[0];
@@ -158,6 +159,9 @@ struct ind_ovs_group {
 
 /* Translate an OVS key into a flat struct */
 void ind_ovs_parse_key(struct nlattr *key, struct ind_ovs_parsed_key *pkey);
+
+/* Translate a parsed key into nlattrs */
+void ind_ovs_emit_key(const struct ind_ovs_parsed_key *key, struct nl_msg *msg, bool omit_zeroes);
 
 /* Translate an OVS key into an OpenFlow match object */
 void ind_ovs_key_to_match(const struct ind_ovs_parsed_key *pkey, of_version_t version, of_match_t *match);
@@ -278,6 +282,12 @@ extern bool ind_ovs_benchmark_mode;
  * Set it with the environment variable IVS_DISABLE_KFLOWS=1.
  */
 extern bool ind_ovs_disable_kflows;
+
+/*
+ * Disable megaflows for debugging and performance comparison.
+ * Set with the environment variable IVS_DISABLE_MEGAFLOWS=1.
+ */
+extern bool ind_ovs_disable_megaflows;
 
 /*
  * Random number used to prevent guests from deliberately causing hash

--- a/modules/OVSDriver/module/src/pktout.c
+++ b/modules/OVSDriver/module/src/pktout.c
@@ -176,7 +176,6 @@ check_for_table_action(of_list_action_t *actions, uint32_t *queue_id)
             break;
         }
         default:
-            LOG_ERROR("unsupported action %s", of_object_id_str[action.object_id]);
             return false;
         }
     }

--- a/modules/OVSDriver/module/src/translate_match.c
+++ b/modules/OVSDriver/module/src/translate_match.c
@@ -82,6 +82,19 @@ ind_ovs_parse_key(struct nlattr *key, struct ind_ovs_parsed_key *pkey)
     assert(ATTR_BITMAP_TEST(pkey->populated, OVS_KEY_ATTR_ETHERNET));
 }
 
+void
+ind_ovs_emit_key(const struct ind_ovs_parsed_key *key, struct nl_msg *msg, bool omit_zero)
+{
+    static uint8_t zeroes[sizeof(*key)];
+#define field(attr, name, type) \
+    if (ATTR_BITMAP_TEST(key->populated, attr) && \
+            (!omit_zero || memcmp(&key->name, zeroes, sizeof(type)))) { \
+        nla_put(msg, attr, sizeof(type), &key->name); \
+    }
+    OVS_KEY_FIELDS
+#undef field
+}
+
 /* Should only be used when creating the match for a packet-in */
 void
 ind_ovs_key_to_match(const struct ind_ovs_parsed_key *pkey,

--- a/modules/OVSDriver/module/src/upcall.c
+++ b/modules/OVSDriver/module/src/upcall.c
@@ -239,6 +239,8 @@ ind_ovs_handle_packet_miss(struct ind_ovs_upcall_thread *thread,
     struct ind_ovs_parsed_key pkey;
     ind_ovs_parse_key(key, &pkey);
 
+    struct ind_ovs_parsed_key mask = { 0 };
+
     xbuf_reset(&thread->stats);
 
     struct nlattr *actions = nla_nest_start(msg, OVS_PACKET_ATTR_ACTIONS);
@@ -246,7 +248,7 @@ ind_ovs_handle_packet_miss(struct ind_ovs_upcall_thread *thread,
     struct action_context actx;
     action_context_init(&actx, &pkey, msg);
 
-    indigo_error_t err = pipeline_process(&pkey, &thread->stats, &actx);
+    indigo_error_t err = pipeline_process(&pkey, &mask, &thread->stats, &actx);
     if (err < 0) {
         return;
     }

--- a/modules/pipeline/module/inc/pipeline/pipeline.h
+++ b/modules/pipeline/module/inc/pipeline/pipeline.h
@@ -37,6 +37,7 @@ struct pipeline_ops {
     void (*finish)(void);
     indigo_error_t (*process)(
         struct ind_ovs_parsed_key *key,
+        struct ind_ovs_parsed_key *mask,
         struct xbuf *stats,
         struct action_context *actx);
 };
@@ -77,6 +78,11 @@ void pipeline_list(of_desc_str_t **ret_pipelines, int *num_pipelines);
 /*
  * Send a packet through the pipeline.
  *
+ * 'key' is the packet key sent by the kernel. 'mask' is the megaflow mask
+ * that will be installed in the kernel. It should be initialized to zeroes
+ * and the pipeline implementation will set each bit where it used the
+ * corresponding key bit in its processing.
+ *
  * 'stats' should be an initialized, empty xbuf. It will be be filled with
  * struct stats_handle. These stats objects may belong to flows or tables
  * (and in the future meters or groups). For example, every table a packet
@@ -86,6 +92,7 @@ void pipeline_list(of_desc_str_t **ret_pipelines, int *num_pipelines);
  */
 indigo_error_t
 pipeline_process(struct ind_ovs_parsed_key *key,
+                 struct ind_ovs_parsed_key *mask,
                  struct xbuf *stats,
                  struct action_context *actx);
 

--- a/modules/pipeline_lua/module/src/pipeline_lua.c
+++ b/modules/pipeline_lua/module/src/pipeline_lua.c
@@ -164,9 +164,14 @@ pipeline_lua_finish(void)
 
 indigo_error_t
 pipeline_lua_process(struct ind_ovs_parsed_key *key,
+                     struct ind_ovs_parsed_key *mask,
                      struct xbuf *stats,
                      struct action_context *actx)
 {
+    uint64_t populated = mask->populated;
+    memset(mask, 0xff, sizeof(*mask));
+    mask->populated = populated;
+
     pipeline_lua_fields_from_key(key, &context.fields);
     context.stats = stats;
     context.actx = actx;

--- a/modules/pipeline_reflect/module/src/pipeline_reflect.c
+++ b/modules/pipeline_reflect/module/src/pipeline_reflect.c
@@ -52,6 +52,7 @@ monotonic_ns(void)
 
 indigo_error_t
 pipeline_reflect_process(struct ind_ovs_parsed_key *key,
+                         struct ind_ovs_parsed_key *mask,
                          struct xbuf *stats,
                          struct action_context *actx)
 {
@@ -59,6 +60,8 @@ pipeline_reflect_process(struct ind_ovs_parsed_key *key,
         uint64_t end_time = monotonic_ns() + delay_ns;
         while (monotonic_ns() <= end_time);
     }
+
+    mask->in_port = -1;
 
     action_output(actx, key->in_port);
     return INDIGO_ERROR_NONE;

--- a/modules/pipeline_standard/module/src/pipeline_standard.c
+++ b/modules/pipeline_standard/module/src/pipeline_standard.c
@@ -124,11 +124,16 @@ pipeline_standard_finish(void)
 
 indigo_error_t
 pipeline_standard_process(struct ind_ovs_parsed_key *key,
+                          struct ind_ovs_parsed_key *mask,
                           struct xbuf *stats,
                           struct action_context *actx)
 {
     struct pipeline_standard_cfr cfr;
     pipeline_standard_key_to_cfr(key, &cfr);
+
+    uint64_t populated = mask->populated;
+    memset(mask, 0xff, sizeof(*mask));
+    mask->populated = populated;
 
     uint32_t hash = murmur_hash(&cfr, sizeof(cfr), 0);
 


### PR DESCRIPTION
Reviewer: @harshsin

Pipeline implementations are given a mask to fill in when processing a
flow. For every key bit it used when processing a flow, the pipeline must
set the corresponding mask bit to one. This mask is sent to the kernel when
inserting a kflow. Any future packets that agree with the kflow key where
the mask bit is one will hit, reducing the number of kflows that need to be
installed.

This change does not yet generate useful masks from the built-in pipelines.