### PR TITLE
OVSDriver: fix a leak of netlink sockets when nl_connect fails

### DIFF
--- a/modules/OVSDriver/module/src/util.c
+++ b/modules/OVSDriver/module/src/util.c
@@ -204,6 +204,7 @@ ind_ovs_create_nlsock(void)
 
     if ((ret = genl_connect(sk)) != 0) {
         LOG_ERROR("failed to connect netlink socket: %s", nl_geterror(ret));
+        nl_socket_free(sk);
         return NULL;
     }
 


### PR DESCRIPTION
Reviewer: trivial