### PR TITLE
build centos7 RPMs using Docker

### DIFF
--- a/.abat-automerge
+++ b/.abat-automerge
@@ -36,6 +36,8 @@ for ARCH in $ARCHS; do
     done
 done
 
+./build/build-rhel-packages.sh
+
 # Publish packages from official builds
 if [ "${PUBLISH_DIR-}" ]; then
     mkdir -p "$PUBLISH_DIR"

--- a/Makefile
+++ b/Makefile
@@ -21,22 +21,22 @@ IVS_BUILD := targets/ivs/build/gcc-local
 IVS_CTL_BUILD := targets/ivs-ctl/build/gcc-local
 
 all:
-	make -C targets/ivs
-	make -C targets/ivs-ctl
+	${MAKE} -C targets/ivs
+	${MAKE} -C targets/ivs-ctl
 
 install: all
 	install -D $(IVS_BUILD)/bin/ivs $(DESTDIR)/usr/sbin/ivs
 	install -D $(IVS_CTL_BUILD)/bin/ivs-ctl $(DESTDIR)/usr/sbin/ivs-ctl
 
 clean:
-	make -C targets/ivs clean
-	make -C targets/ivs-ctl clean
+	${MAKE} -C targets/ivs clean
+	${MAKE} -C targets/ivs-ctl clean
 	# The build system creates these even during make clean
 	rm -f modules/OVSDriver/OVSDriver.mk targets/ivs-ctl/IVSCtl.mk targets/ivs/Manifest.mk targets/ivs/IVS.mk targets/ivs/dependmodules.x
 	(cd indigo; rm -f modules/AIM/AIM.mk modules/BigData/BigList/BigList.mk modules/ELS/ELS.mk modules/FME/FME.mk modules/IOF/IOF.mk modules/IVS/IVS.mk modules/Indigo/OFConnectionManager/OFConnectionManager.mk modules/Indigo/OFStateManager/OFStateManager.mk modules/Indigo/SocketManager/SocketManager.mk modules/Indigo/indigo/indigo.mk modules/NSS/NSS.mk modules/PPE/PPE.mk modules/loci/loci.mk modules/murmur/murmur.mk modules/uCli/uCli.mk)
 
 deb:
-	fakeroot make -f debian/rules binary
+	fakeroot ${MAKE} -f debian/rules binary
 
 rpm:
 	rhel/rpm-from-source

--- a/build/build-rhel-packages-inner.sh
+++ b/build/build-rhel-packages-inner.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eux
+SPEC="/rpmbuild/SOURCES/ivs-7.0.spec"
+
+# RPM runs as root and doesn't like source files owned by a random UID
+OUTER_UID=$(stat -c '%u' $SPEC)
+OUTER_GID=$(stat -c '%g' $SPEC)
+trap "chown -R $OUTER_UID:$OUTER_GID /rpmbuild" EXIT
+chown -R root:root /rpmbuild
+
+rpmbuild -bb $SPEC

--- a/build/build-rhel-packages.sh
+++ b/build/build-rhel-packages.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -eux
+################################################################
+#
+#        Copyright 2015, Big Switch Networks, Inc.
+#
+# Licensed under the Eclipse Public License, Version 1.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#        http://www.eclipse.org/legal/epl-v10.html
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the
+# License.
+#
+################################################################
+
+ROOTDIR=$(dirname $(readlink -f $0))/..
+cd "$ROOTDIR"
+
+: Build ID: ${BUILD_ID:=devel}
+
+BUILDDIR=$(mktemp -d)
+
+mkdir -p $BUILDDIR/SOURCES $BUILDDIR/RPMS
+
+# Copy source code to a volume that will be mounted in the container
+cp build/build-rhel-packages-inner.sh $BUILDDIR/build-rhel-packages-inner.sh
+cp rhel/ivs-7.0.spec $BUILDDIR/SOURCES
+./build/files.sh | tar -T- -c -z -f $BUILDDIR/SOURCES/ivs.tar.gz --transform 's,^,ivs/,'
+
+docker.io run -v $BUILDDIR:/rpmbuild bigswitch/ivs-builder:centos7 /rpmbuild/build-rhel-packages-inner.sh
+
+# Copy built RPMs to pkg/
+OUTDIR=$(readlink -m "pkg/centos7-x86_64/$BUILD_ID")
+rm -rf "$OUTDIR" && mkdir -p "$OUTDIR"
+mv $BUILDDIR/RPMS/x86_64/*.rpm "$OUTDIR"
+git log > "$OUTDIR/gitlog.txt"
+touch "$OUTDIR/build-$BUILD_ID"
+ln -snf $(basename $OUTDIR) $OUTDIR/../latest
+
+rm -rf "$BUILDDIR"

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -1,0 +1,4 @@
+FROM centos:centos7
+MAINTAINER Rich Lane <rlane@bigswitch.com>
+RUN yum groupinstall -y 'Development Tools'
+RUN yum install -y libnl3-devel

--- a/rhel/ivs-7.0.spec
+++ b/rhel/ivs-7.0.spec
@@ -18,6 +18,7 @@
 
 Name: ivs
 Summary: Indigo Virtual Switch
+Group: System Environment/Daemons
 URL: http://www.bigswitch.com/
 Version: 0.5
 Release: 1%{?dist}
@@ -28,6 +29,9 @@ Source: ivs.tar.gz
 Requires(post):  systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units
+
+Requires: libnl3
+BuildRequires: bash, python, pkgconfig, libnl3-devel
 
 %description
 Indigo Virtual Switch (IVS) is a pure OpenFlow virtual switch designed for high

--- a/rhel/ivs-7.0.spec
+++ b/rhel/ivs-7.0.spec
@@ -44,7 +44,7 @@ platform][1], which provides a common core for many physical and virtual switche
 %setup -q -n ivs
 
 %build
-make
+make RELEASE=1
 
 %install
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Reviewer: @harshsin

I created a bigswitch/ivs-builder Docker repo with one tag for
"centos7". This Docker image has all the build dependencies for IVS.
When you run the build-rhel-packages.sh script, it will download this
image, copy the IVS source code into it, run rpmbuild, and extract the
resulting RPMs. After the image has been been downloaded (which only
happens the first time) the build completes in about a minute.