### PR TITLE
add capability for the pipeline to create/destroy pktin netlink sockets

### DIFF
--- a/modules/OVSDriver/module/src/ovs_driver.c
+++ b/modules/OVSDriver/module/src/ovs_driver.c
@@ -51,6 +51,8 @@ bool ind_ovs_disable_megaflows = false;
 uint32_t ind_ovs_salt;
 uint16_t ind_ovs_inband_vlan = VLAN_INVALID;
 
+struct ind_ovs_pktin_socket pktout_soc;
+
 static int
 ind_ovs_create_datapath(const char *name)
 {
@@ -234,6 +236,8 @@ ind_ovs_init(const char *datapath_name)
     ind_ovs_port_init();
     ind_ovs_vlan_stats_init();
     ind_ovs_barrier_init();
+    ind_ovs_pktin_socket_register(&pktout_soc, NULL, PKTIN_INTERVAL,
+                                  PKTIN_BURST_SIZE);
 
     if ((ret = ind_ovs_create_datapath(datapath_name)) != 0) {
         LOG_ERROR("failed to create OVS datapath");
@@ -260,6 +264,7 @@ ind_ovs_finish(void)
 {
     ind_ovs_port_finish();
     ind_ovs_upcall_finish();
+    ind_ovs_pktin_socket_unregister(&pktout_soc);
     (void) ind_ovs_destroy_datapath();
     ind_ovs_nlmsg_freelist_finish();
 }

--- a/modules/OVSDriver/module/src/ovs_driver.c
+++ b/modules/OVSDriver/module/src/ovs_driver.c
@@ -51,7 +51,7 @@ bool ind_ovs_disable_megaflows = false;
 uint32_t ind_ovs_salt;
 uint16_t ind_ovs_inband_vlan = VLAN_INVALID;
 
-struct ind_ovs_pktin_socket pktout_soc;
+struct ind_ovs_pktin_socket ind_ovs_pktout_soc;
 
 static int
 ind_ovs_create_datapath(const char *name)
@@ -236,7 +236,7 @@ ind_ovs_init(const char *datapath_name)
     ind_ovs_port_init();
     ind_ovs_vlan_stats_init();
     ind_ovs_barrier_init();
-    ind_ovs_pktin_socket_register(&pktout_soc, NULL, PKTIN_INTERVAL,
+    ind_ovs_pktin_socket_register(&ind_ovs_pktout_soc, NULL, PKTIN_INTERVAL,
                                   PKTIN_BURST_SIZE);
 
     if ((ret = ind_ovs_create_datapath(datapath_name)) != 0) {
@@ -264,7 +264,7 @@ ind_ovs_finish(void)
 {
     ind_ovs_port_finish();
     ind_ovs_upcall_finish();
-    ind_ovs_pktin_socket_unregister(&pktout_soc);
+    ind_ovs_pktin_socket_unregister(&ind_ovs_pktout_soc);
     (void) ind_ovs_destroy_datapath();
     ind_ovs_nlmsg_freelist_finish();
 }

--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -297,4 +297,6 @@ extern bool ind_ovs_disable_megaflows;
  */
 extern uint32_t ind_ovs_salt;
 
+extern struct ind_ovs_pktin_socket pktout_soc;
+
 #endif

--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -297,6 +297,10 @@ extern bool ind_ovs_disable_megaflows;
  */
 extern uint32_t ind_ovs_salt;
 
-extern struct ind_ovs_pktin_socket pktout_soc;
+/*
+ * Netlink socket to be used for sending pktin's to the controller from
+ * pktout path.
+ */
+extern struct ind_ovs_pktin_socket ind_ovs_pktout_soc;
 
 #endif

--- a/modules/OVSDriver/module/src/pktin.c
+++ b/modules/OVSDriver/module/src/pktin.c
@@ -23,7 +23,7 @@
 
 static aim_ratelimiter_t ind_ovs_pktin_limiter;
 
-static indigo_error_t
+indigo_error_t
 ind_ovs_pktin(of_port_no_t in_port,
               uint8_t *data, unsigned int len, uint8_t reason, uint64_t metadata,
               struct ind_ovs_parsed_key *pkey)

--- a/modules/OVSDriver/module/src/pktin_socket.c
+++ b/modules/OVSDriver/module/src/pktin_socket.c
@@ -1,0 +1,118 @@
+/****************************************************************
+ *
+ *        Copyright 2015, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+#include "ovs_driver_int.h"
+#include <indigo/of_state_manager.h>
+#include <SocketManager/socketmanager.h>
+#include <debug_counter/debug_counter.h>
+
+DEBUG_COUNTER(pktin_ratelimited, "ovsdriver.pktin.ratelimited",
+              "Dropped packet-in because of the ratelimiter");
+
+static int
+ind_ovs_pktin_socket_recv(struct nl_msg *msg, void *arg)
+{
+    struct ind_ovs_pktin_socket *soc = arg;
+
+    if (!ind_ovs_benchmark_mode && aim_ratelimiter_limit(&soc->pktin_limiter, monotonic_us()) != 0) {
+        debug_counter_inc(&pktin_ratelimited);
+        return NL_OK;
+    }
+
+    struct nlmsghdr *nlh = nlmsg_hdr(msg);
+    assert(nlh->nlmsg_type == ovs_packet_family);
+
+    struct nlattr *attrs[OVS_PACKET_ATTR_MAX+1];
+    if (genlmsg_parse(nlh, sizeof(struct ovs_header),
+                      attrs, OVS_PACKET_ATTR_MAX,
+                      NULL) < 0) {
+        LOG_ERROR("failed to parse packet message");
+        abort();
+    }
+
+    LOG_VERBOSE("Received packet-in message:");
+    ind_ovs_dump_msg(nlmsg_hdr(msg));
+
+    struct nlattr *key = attrs[OVS_PACKET_ATTR_KEY];
+    struct nlattr *packet = attrs[OVS_PACKET_ATTR_PACKET];
+    struct nlattr *userdata_nla = attrs[OVS_PACKET_ATTR_USERDATA];
+    assert(key && packet && userdata_nla);
+
+    struct ind_ovs_parsed_key pkey;
+    ind_ovs_parse_key(key, &pkey);
+
+    uint64_t userdata = nla_get_u64(userdata_nla);
+
+    if (soc->callback) {
+        soc->callback(nla_data(packet), nla_len(packet),
+                      IVS_PKTIN_REASON(userdata),
+                      IVS_PKTIN_METADATA(userdata), &pkey);
+    } else {
+        ind_ovs_pktin(pkey.in_port,
+                      nla_data(packet), nla_len(packet),
+                      IVS_PKTIN_REASON(userdata),
+                      IVS_PKTIN_METADATA(userdata),
+                      &pkey);
+    }
+
+    return NL_OK;
+}
+
+static void
+ind_ovs_pktin_socket_ready(int socket_id, void *cookie,
+                           int read_ready, int write_ready, int error_seen)
+{
+    struct ind_ovs_pktin_socket *soc = cookie;
+    nl_recvmsgs_default(soc->pktin_socket);
+}
+
+void
+ind_ovs_pktin_socket_register(struct ind_ovs_pktin_socket *soc)
+{
+    /* Create the netlink socket */
+    soc->pktin_socket = ind_ovs_create_nlsock();
+    if (soc->pktin_socket == NULL) {
+        LOG_ERROR("failed to create netlink socket");
+        return;
+    }
+
+    /* Set it to non-blocking */
+    if (nl_socket_set_nonblocking(soc->pktin_socket) < 0) {
+        LOG_ERROR("failed to set netlink socket nonblocking");
+        nl_socket_free(soc->pktin_socket);
+        return;
+    }
+
+    /* Register with socket manager */
+    if (ind_soc_socket_register(nl_socket_get_fd(soc->pktin_socket),
+                                ind_ovs_pktin_socket_ready, soc) < 0) {
+        LOG_ERROR("failed to register socket");
+        abort();
+    }
+
+    nl_socket_modify_cb(soc->pktin_socket, NL_CB_VALID, NL_CB_CUSTOM,
+                        ind_ovs_pktin_socket_recv, soc);
+}
+
+void
+ind_ovs_pktin_socket_unregister(struct ind_ovs_pktin_socket *soc)
+{
+    ind_soc_socket_unregister(nl_socket_get_fd(soc->pktin_socket));
+    nl_socket_free(soc->pktin_socket);
+}

--- a/modules/OVSDriver/module/src/pktin_socket.c
+++ b/modules/OVSDriver/module/src/pktin_socket.c
@@ -82,14 +82,14 @@ ind_ovs_pktin_socket_ready(int socket_id, void *cookie,
 }
 
 uint32_t
-ind_ovs_pktin_socket_lookup_netlink(struct ind_ovs_pktin_socket *soc)
+ind_ovs_pktin_socket_netlink_port(struct ind_ovs_pktin_socket *soc)
 {
     return nl_socket_get_local_port(soc->pktin_socket);
 }
 
 void
 ind_ovs_pktin_socket_register(struct ind_ovs_pktin_socket *soc,
-                              ind_ovs_pktin_get_f callback,
+                              ind_ovs_pktin_cb_f callback,
                               uint32_t interval, uint32_t burst)
 {
     /* Create the netlink socket */

--- a/modules/OVSDriver/module/src/pktout.c
+++ b/modules/OVSDriver/module/src/pktout.c
@@ -226,7 +226,7 @@ translate_openflow_actions(of_list_action_t *actions, struct ind_ovs_parsed_key 
                 case OF_PORT_DEST_CONTROLLER: {
                     uint8_t reason = OF_PACKET_IN_REASON_ACTION;
                     uint64_t userdata = IVS_PKTIN_USERDATA(reason, 0);
-                    uint32_t netlink_port = ind_ovs_pktin_socket_netlink_port(&pktout_soc);
+                    uint32_t netlink_port = ind_ovs_pktin_socket_netlink_port(&ind_ovs_pktout_soc);
                     action_userspace(&ctx, &userdata, sizeof(uint64_t), netlink_port);
                     break;
                 }

--- a/modules/OVSDriver/module/src/pktout.c
+++ b/modules/OVSDriver/module/src/pktout.c
@@ -226,7 +226,8 @@ translate_openflow_actions(of_list_action_t *actions, struct ind_ovs_parsed_key 
                 case OF_PORT_DEST_CONTROLLER: {
                     uint8_t reason = OF_PACKET_IN_REASON_ACTION;
                     uint64_t userdata = IVS_PKTIN_USERDATA(reason, 0);
-                    action_controller(&ctx, userdata);
+                    uint32_t netlink_port = ind_ovs_pktin_socket_lookup_netlink(&pktout_soc);
+                    action_userspace(&ctx, &userdata, sizeof(uint64_t), netlink_port);
                     break;
                 }
                 case OF_PORT_DEST_ALL:

--- a/modules/OVSDriver/module/src/pktout.c
+++ b/modules/OVSDriver/module/src/pktout.c
@@ -226,7 +226,7 @@ translate_openflow_actions(of_list_action_t *actions, struct ind_ovs_parsed_key 
                 case OF_PORT_DEST_CONTROLLER: {
                     uint8_t reason = OF_PACKET_IN_REASON_ACTION;
                     uint64_t userdata = IVS_PKTIN_USERDATA(reason, 0);
-                    uint32_t netlink_port = ind_ovs_pktin_socket_lookup_netlink(&pktout_soc);
+                    uint32_t netlink_port = ind_ovs_pktin_socket_netlink_port(&pktout_soc);
                     action_userspace(&ctx, &userdata, sizeof(uint64_t), netlink_port);
                     break;
                 }

--- a/modules/ivs/module/inc/ivs/ivs.h
+++ b/modules/ivs/module/inc/ivs/ivs.h
@@ -31,6 +31,7 @@
 #include <loci/loci.h>
 #include <stats/stats.h>
 #include <indigo/of_connection_manager.h>
+#include <AIM/aim_rl.h>
 
 #define VLAN_CFI_BIT (1<<12)
 #define VLAN_TCI(vid, pcp) ( (((pcp) & 0x7) << 13) | ((vid) & 0xfff) )
@@ -133,6 +134,15 @@ struct ind_ovs_port_counters {
     struct stats_handle tx_multicast_stats_handle;
 };
 
+typedef void (*ind_ovs_pktin_get) (uint8_t *data, unsigned int len,
+                                   uint8_t reason, uint64_t metadata,
+                                   struct ind_ovs_parsed_key *pkey);
+struct ind_ovs_pktin_socket {
+    struct nl_sock *pktin_socket; /* Netlink socket for packet-ins */
+    aim_ratelimiter_t pktin_limiter; /* Ratelimiter for packet-ins recv'd on this socket */
+    ind_ovs_pktin_get callback; /* Callback to get packet-ins recv'd on this socket */
+};
+
 /*
  * Exported from OVSDriver for use by the pipeline
  */
@@ -147,5 +157,10 @@ void ind_ovs_barrier_defer_revalidation(indigo_cxn_id_t cxn_id);
 bool ind_ovs_uplink_check(of_port_no_t port_no);
 of_port_no_t ind_ovs_uplink_first(void);
 extern uint16_t ind_ovs_inband_vlan;
+void ind_ovs_pktin_socket_register(struct ind_ovs_pktin_socket *soc);
+void ind_ovs_pktin_socket_unregister(struct ind_ovs_pktin_socket *soc);
+indigo_error_t ind_ovs_pktin(of_port_no_t in_port, uint8_t *data,
+                             unsigned int len, uint8_t reason, uint64_t metadata,
+                             struct ind_ovs_parsed_key *pkey);
 
 #endif

--- a/modules/ivs/module/inc/ivs/ivs.h
+++ b/modules/ivs/module/inc/ivs/ivs.h
@@ -134,14 +134,16 @@ struct ind_ovs_port_counters {
     struct stats_handle tx_multicast_stats_handle;
 };
 
-typedef void (*ind_ovs_pktin_get) (uint8_t *data, unsigned int len,
+typedef void (*ind_ovs_pktin_get_f) (uint8_t *data, unsigned int len,
                                    uint8_t reason, uint64_t metadata,
                                    struct ind_ovs_parsed_key *pkey);
 struct ind_ovs_pktin_socket {
     struct nl_sock *pktin_socket; /* Netlink socket for packet-ins */
     aim_ratelimiter_t pktin_limiter; /* Ratelimiter for packet-ins recv'd on this socket */
-    ind_ovs_pktin_get callback; /* Callback to get packet-ins recv'd on this socket */
+    ind_ovs_pktin_get_f callback; /* Callback to get packet-ins recv'd on this socket */
 };
+
+extern struct ind_ovs_pktin_socket pktout_soc;
 
 /*
  * Exported from OVSDriver for use by the pipeline
@@ -157,7 +159,10 @@ void ind_ovs_barrier_defer_revalidation(indigo_cxn_id_t cxn_id);
 bool ind_ovs_uplink_check(of_port_no_t port_no);
 of_port_no_t ind_ovs_uplink_first(void);
 extern uint16_t ind_ovs_inband_vlan;
-void ind_ovs_pktin_socket_register(struct ind_ovs_pktin_socket *soc);
+uint32_t ind_ovs_pktin_socket_lookup_netlink(struct ind_ovs_pktin_socket *soc);
+void ind_ovs_pktin_socket_register(struct ind_ovs_pktin_socket *soc,
+                                   ind_ovs_pktin_get_f callback,
+                                   uint32_t interval, uint32_t burst);
 void ind_ovs_pktin_socket_unregister(struct ind_ovs_pktin_socket *soc);
 indigo_error_t ind_ovs_pktin(of_port_no_t in_port, uint8_t *data,
                              unsigned int len, uint8_t reason, uint64_t metadata,

--- a/modules/ivs/module/inc/ivs/ivs.h
+++ b/modules/ivs/module/inc/ivs/ivs.h
@@ -134,16 +134,14 @@ struct ind_ovs_port_counters {
     struct stats_handle tx_multicast_stats_handle;
 };
 
-typedef void (*ind_ovs_pktin_get_f) (uint8_t *data, unsigned int len,
-                                   uint8_t reason, uint64_t metadata,
-                                   struct ind_ovs_parsed_key *pkey);
+typedef void (*ind_ovs_pktin_cb_f) (uint8_t *data, unsigned int len,
+                                    uint8_t reason, uint64_t metadata,
+                                    struct ind_ovs_parsed_key *pkey);
 struct ind_ovs_pktin_socket {
     struct nl_sock *pktin_socket; /* Netlink socket for packet-ins */
     aim_ratelimiter_t pktin_limiter; /* Ratelimiter for packet-ins recv'd on this socket */
-    ind_ovs_pktin_get_f callback; /* Callback to get packet-ins recv'd on this socket */
+    ind_ovs_pktin_cb_f callback; /* Callback to get packet-ins recv'd on this socket */
 };
-
-extern struct ind_ovs_pktin_socket pktout_soc;
 
 /*
  * Exported from OVSDriver for use by the pipeline
@@ -159,9 +157,9 @@ void ind_ovs_barrier_defer_revalidation(indigo_cxn_id_t cxn_id);
 bool ind_ovs_uplink_check(of_port_no_t port_no);
 of_port_no_t ind_ovs_uplink_first(void);
 extern uint16_t ind_ovs_inband_vlan;
-uint32_t ind_ovs_pktin_socket_lookup_netlink(struct ind_ovs_pktin_socket *soc);
+uint32_t ind_ovs_pktin_socket_netlink_port(struct ind_ovs_pktin_socket *soc);
 void ind_ovs_pktin_socket_register(struct ind_ovs_pktin_socket *soc,
-                                   ind_ovs_pktin_get_f callback,
+                                   ind_ovs_pktin_cb_f callback,
                                    uint32_t interval, uint32_t burst);
 void ind_ovs_pktin_socket_unregister(struct ind_ovs_pktin_socket *soc);
 indigo_error_t ind_ovs_pktin(of_port_no_t in_port, uint8_t *data,

--- a/modules/pipeline_standard/module/src/action.c
+++ b/modules/pipeline_standard/module/src/action.c
@@ -48,9 +48,12 @@ pipeline_standard_translate_actions(
     XBUF_FOREACH(xbuf_data(xbuf), xbuf_length(xbuf), attr) {
         switch (attr->nla_type) {
         /* Output actions */
-        case IND_OVS_ACTION_CONTROLLER:
-            action_controller(ctx, *XBUF_PAYLOAD(attr, uint64_t));
+        case IND_OVS_ACTION_CONTROLLER: {
+            uint64_t userdata = *XBUF_PAYLOAD(attr, uint64_t);
+            uint32_t netlink_port = ind_ovs_pktin_socket_lookup_netlink(&pktout_soc);
+            action_userspace(ctx, &userdata, sizeof(uint64_t), netlink_port);
             break;
+        }
         case IND_OVS_ACTION_OUTPUT:
             action_output(ctx, *XBUF_PAYLOAD(attr, uint32_t));
             break;

--- a/modules/pipeline_standard/module/src/action.c
+++ b/modules/pipeline_standard/module/src/action.c
@@ -50,7 +50,7 @@ pipeline_standard_translate_actions(
         /* Output actions */
         case IND_OVS_ACTION_CONTROLLER: {
             uint64_t userdata = *XBUF_PAYLOAD(attr, uint64_t);
-            uint32_t netlink_port = ind_ovs_pktin_socket_lookup_netlink(&pktout_soc);
+            uint32_t netlink_port = ind_ovs_pktin_socket_netlink_port(&pktin_soc);
             action_userspace(ctx, &userdata, sizeof(uint64_t), netlink_port);
             break;
         }

--- a/modules/pipeline_standard/module/src/action.h
+++ b/modules/pipeline_standard/module/src/action.h
@@ -75,4 +75,6 @@ void pipeline_standard_translate_actions(
     struct action_context *ctx, struct xbuf *actions,
     uint32_t hash, struct xbuf *stats);
 
+extern struct ind_ovs_pktin_socket pktin_soc;
+
 #endif

--- a/modules/pipeline_standard/module/src/action.h
+++ b/modules/pipeline_standard/module/src/action.h
@@ -75,6 +75,7 @@ void pipeline_standard_translate_actions(
     struct action_context *ctx, struct xbuf *actions,
     uint32_t hash, struct xbuf *stats);
 
+/* Netlink socket to be used for receiving pktin's */
 extern struct ind_ovs_pktin_socket pktin_soc;
 
 #endif

--- a/modules/pipeline_standard/module/src/pipeline_standard.c
+++ b/modules/pipeline_standard/module/src/pipeline_standard.c
@@ -84,7 +84,7 @@ static int openflow_version = -1;
 static struct flowtable *flowtables[NUM_TABLES];
 static const indigo_core_table_ops_t table_ops;
 
-static struct ind_ovs_pktin_socket pktin_soc;
+struct ind_ovs_pktin_socket pktin_soc;
 
 static void
 pipeline_standard_init(const char *name)
@@ -169,7 +169,7 @@ pipeline_standard_process(struct ind_ovs_parsed_key *key,
         if (tcam_entry == NULL) {
             if (openflow_version < OF_VERSION_1_3) {
                 uint64_t userdata = IVS_PKTIN_USERDATA(OF_PACKET_IN_REASON_NO_MATCH, 0);
-                uint32_t netlink_port = ind_ovs_pktin_socket_lookup_netlink(&pktin_soc);
+                uint32_t netlink_port = ind_ovs_pktin_socket_netlink_port(&pktin_soc);
                 action_userspace(actx, &userdata, sizeof(uint64_t), netlink_port);
             }
             pipeline_add_stats(stats, &flowtable->missed_stats_handle);

--- a/modules/pipeline_standard/module/src/pipeline_standard.c
+++ b/modules/pipeline_standard/module/src/pipeline_standard.c
@@ -39,6 +39,12 @@ AIM_LOG_STRUCT_DEFINE(AIM_LOG_OPTIONS_DEFAULT, AIM_LOG_BITS_DEFAULT, NULL, 0);
 
 #define NUM_TABLES 16
 
+/* Overall minimum average interval between packet-ins (in us) */
+#define PKTIN_INTERVAL 3000
+
+/* Overall packet-in burstiness tolerance. */
+#define PKTIN_BURST_SIZE 32
+
 struct flowtable {
     struct tcam *tcam;
     struct stats_handle matched_stats_handle;
@@ -78,6 +84,8 @@ static int openflow_version = -1;
 static struct flowtable *flowtables[NUM_TABLES];
 static const indigo_core_table_ops_t table_ops;
 
+static struct ind_ovs_pktin_socket pktin_soc;
+
 static void
 pipeline_standard_init(const char *name)
 {
@@ -105,6 +113,9 @@ pipeline_standard_init(const char *name)
     if (openflow_version == OF_VERSION_1_3) {
         pipeline_standard_group_register();
     }
+
+    ind_ovs_pktin_socket_register(&pktin_soc, NULL, PKTIN_INTERVAL,
+                                  PKTIN_BURST_SIZE);
 }
 
 static void
@@ -122,6 +133,8 @@ pipeline_standard_finish(void)
     if (openflow_version == OF_VERSION_1_3) {
         pipeline_standard_group_unregister();
     }
+
+    ind_ovs_pktin_socket_unregister(&pktin_soc);
 }
 
 indigo_error_t
@@ -156,7 +169,8 @@ pipeline_standard_process(struct ind_ovs_parsed_key *key,
         if (tcam_entry == NULL) {
             if (openflow_version < OF_VERSION_1_3) {
                 uint64_t userdata = IVS_PKTIN_USERDATA(OF_PACKET_IN_REASON_NO_MATCH, 0);
-                action_controller(actx, userdata);
+                uint32_t netlink_port = ind_ovs_pktin_socket_lookup_netlink(&pktin_soc);
+                action_userspace(actx, &userdata, sizeof(uint64_t), netlink_port);
             }
             pipeline_add_stats(stats, &flowtable->missed_stats_handle);
             break;


### PR DESCRIPTION
Reviewer: @rlane 

Commit Summary: Allow pipelines to register netlink sockets to receive pktin's. Pipeline will set the callback to be associated with each socket which will be invoked when a packet is recv'd on that socket. 
Pipeline will also set the ratelimiter associated with that socket.

Todo: Add timer to pause/resume the socket on ratelimiter overflow.