### PR TITLE
shared debug counters

### DIFF
--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -39,6 +39,7 @@
 #include "BigHash/bighash.h"
 #include <stats/stats.h>
 #include <debug_counter/debug_counter.h>
+#include <shared_debug_counter/shared_debug_counter.h>
 
 #define IND_OVS_MAX_PORTS 1024
 

--- a/modules/shared_debug_counter/.gitignore
+++ b/modules/shared_debug_counter/.gitignore
@@ -1,0 +1,1 @@
+/shared_debug_counter.mk

--- a/modules/shared_debug_counter/module/inc/shared_debug_counter/shared_debug_counter.h
+++ b/modules/shared_debug_counter/module/inc/shared_debug_counter/shared_debug_counter.h
@@ -1,0 +1,53 @@
+/****************************************************************
+ *
+ *        Copyright 2015, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+/*
+ * This module is a wrapper around debug counters which places them in shared
+ * memory. This is necessary for debug counter updates from upcall processes to
+ * be persistent and visible to the controller.
+ *
+ * It's implemented by placing the debug counters in a special section, which
+ * is aligned and padded to the page size. When shared_debug_counter_init is
+ * called it replaces these pages (which were private mappings) with a shared
+ * mapping. When a child process is forked it will be able to write to these
+ * pages without triggering COW.
+ *
+ * One potential downside is that all upcall processes are contending for the
+ * same cachelines when incrementing debug counters. If we find this is a real
+ * performance problem then we could allocate a shared memory region per-process
+ * and periodically synchronize them in the main process.
+ */
+
+#ifndef SHARED_DEBUG_COUNTER_H
+#define SHARED_DEBUG_COUNTER_H
+
+#include <debug_counter/debug_counter.h>
+
+/* Modified from debug_counter.h */
+#define SHARED_DEBUG_COUNTER(ident, name, description) \
+    static __attribute__((section(".shared_debug_counter"))) debug_counter_t ident; \
+    static void __attribute__((constructor)) ident ## _constructor(void) \
+    { \
+        debug_counter_register(&ident, name, description); \
+    }
+
+/* Must be called before any processes are forked */
+void shared_debug_counter_init(void);
+
+#endif

--- a/modules/shared_debug_counter/module/make.mk
+++ b/modules/shared_debug_counter/module/make.mk
@@ -1,6 +1,6 @@
 ################################################################
 #
-#        Copyright 2013, Big Switch Networks, Inc.
+#        Copyright 2015, Big Switch Networks, Inc.
 #
 # Licensed under the Eclipse Public License, Version 1.0 (the
 # "License"); you may not use this file except in compliance
@@ -17,18 +17,6 @@
 #
 ################################################################
 
-BASEDIR := $(dir $(lastword $(MAKEFILE_LIST)))
-OVSDriver_BASEDIR := $(BASEDIR)/OVSDriver
-flowtable_BASEDIR := $(BASEDIR)/flowtable
-l2table_BASEDIR := $(BASEDIR)/l2table
-luajit_BASEDIR := $(BASEDIR)/luajit
-xbuf_BASEDIR := $(BASEDIR)/xbuf
-pipeline_BASEDIR := $(BASEDIR)/pipeline
-pipeline_lua_BASEDIR := $(BASEDIR)/pipeline_lua
-pipeline_standard_BASEDIR := $(BASEDIR)/pipeline_standard
-ivs_common_BASEDIR := $(BASEDIR)/ivs
-tcam_BASEDIR := $(BASEDIR)/tcam
-action_BASEDIR := $(BASEDIR)/action
-stats_BASEDIR := $(BASEDIR)/stats
-pipeline_reflect_BASEDIR := $(BASEDIR)/pipeline_reflect
-shared_debug_counter_BASEDIR := $(BASEDIR)/shared_debug_counter
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+shared_debug_counter_INCLUDES := -I $(THIS_DIR)inc
+shared_debug_counter_INTERNAL_INCLUDES := -I $(THIS_DIR)src

--- a/modules/shared_debug_counter/module/src/link.ld
+++ b/modules/shared_debug_counter/module/src/link.ld
@@ -1,0 +1,9 @@
+/* Align and pad the shared debug counter section to the page size */
+SECTIONS {
+	. = ALIGN(4096);
+        shared_debug_counter_start = .;
+	.shared_debug_counter : { *(.shared_debug_counter) }
+        shared_debug_counter_end = .;
+	. = ALIGN(4096);
+}
+INSERT AFTER .data;

--- a/modules/shared_debug_counter/module/src/make.mk
+++ b/modules/shared_debug_counter/module/src/make.mk
@@ -1,6 +1,6 @@
 ################################################################
 #
-#        Copyright 2013, Big Switch Networks, Inc.
+#        Copyright 2015, Big Switch Networks, Inc.
 #
 # Licensed under the Eclipse Public License, Version 1.0 (the
 # "License"); you may not use this file except in compliance
@@ -17,18 +17,7 @@
 #
 ################################################################
 
-BASEDIR := $(dir $(lastword $(MAKEFILE_LIST)))
-OVSDriver_BASEDIR := $(BASEDIR)/OVSDriver
-flowtable_BASEDIR := $(BASEDIR)/flowtable
-l2table_BASEDIR := $(BASEDIR)/l2table
-luajit_BASEDIR := $(BASEDIR)/luajit
-xbuf_BASEDIR := $(BASEDIR)/xbuf
-pipeline_BASEDIR := $(BASEDIR)/pipeline
-pipeline_lua_BASEDIR := $(BASEDIR)/pipeline_lua
-pipeline_standard_BASEDIR := $(BASEDIR)/pipeline_standard
-ivs_common_BASEDIR := $(BASEDIR)/ivs
-tcam_BASEDIR := $(BASEDIR)/tcam
-action_BASEDIR := $(BASEDIR)/action
-stats_BASEDIR := $(BASEDIR)/stats
-pipeline_reflect_BASEDIR := $(BASEDIR)/pipeline_reflect
-shared_debug_counter_BASEDIR := $(BASEDIR)/shared_debug_counter
+LIBRARY := shared_debug_counter
+$(LIBRARY)_SUBDIR := $(dir $(lastword $(MAKEFILE_LIST)))
+LDFLAGS += -T $(shared_debug_counter_SUBDIR)/link.ld
+include $(BUILDER)/lib.mk

--- a/modules/shared_debug_counter/module/src/make.mk
+++ b/modules/shared_debug_counter/module/src/make.mk
@@ -19,5 +19,5 @@
 
 LIBRARY := shared_debug_counter
 $(LIBRARY)_SUBDIR := $(dir $(lastword $(MAKEFILE_LIST)))
-LDFLAGS += -T $(shared_debug_counter_SUBDIR)/link.ld
+LDFLAGS += -Xlinker -T$(shared_debug_counter_SUBDIR)/link.ld
 include $(BUILDER)/lib.mk

--- a/modules/shared_debug_counter/module/src/shared_debug_counter.c
+++ b/modules/shared_debug_counter/module/src/shared_debug_counter.c
@@ -26,14 +26,11 @@
 #define AIM_LOG_MODULE_NAME shared_debug_counter
 #include <AIM/aim_log.h>
 
-#define ALIGN(x, y) (((x) + (y) - 1) & ~((y) - 1))
-
 void __attribute__((noinline))
 shared_debug_counter_init(void)
 {
     extern char shared_debug_counter_start[], shared_debug_counter_end[];
     int len = shared_debug_counter_end - shared_debug_counter_start;
-    int aligned_len = ALIGN(len, sysconf(_SC_PAGESIZE));
 
     if (len == 0) {
         return;
@@ -41,11 +38,7 @@ shared_debug_counter_init(void)
 
     void *copy = aim_memdup(shared_debug_counter_start, len);
 
-    if (munmap(shared_debug_counter_start, aligned_len) < 0) {
-        AIM_DIE("munmap failed: %s", strerror(errno));
-    }
-
-    if (mmap(shared_debug_counter_start, aligned_len, PROT_READ|PROT_WRITE,
+    if (mmap(shared_debug_counter_start, len, PROT_READ|PROT_WRITE,
              MAP_SHARED|MAP_ANONYMOUS|MAP_FIXED, -1, 0) == MAP_FAILED) {
         AIM_DIE("mmap failed: %s", strerror(errno));
     }

--- a/modules/shared_debug_counter/module/src/shared_debug_counter.c
+++ b/modules/shared_debug_counter/module/src/shared_debug_counter.c
@@ -1,0 +1,55 @@
+/****************************************************************
+ *
+ *        Copyright 2015, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+#include <shared_debug_counter/shared_debug_counter.h>
+#include <AIM/aim.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include <unistd.h>
+
+#define AIM_LOG_MODULE_NAME shared_debug_counter
+#include <AIM/aim_log.h>
+
+#define ALIGN(x, y) (((x) + (y) - 1) & ~((y) - 1))
+
+void __attribute__((noinline))
+shared_debug_counter_init(void)
+{
+    extern char shared_debug_counter_start[], shared_debug_counter_end[];
+    int len = shared_debug_counter_end - shared_debug_counter_start;
+    int aligned_len = ALIGN(len, sysconf(_SC_PAGESIZE));
+
+    if (len == 0) {
+        return;
+    }
+
+    void *copy = aim_memdup(shared_debug_counter_start, len);
+
+    if (munmap(shared_debug_counter_start, aligned_len) < 0) {
+        AIM_DIE("munmap failed: %s", strerror(errno));
+    }
+
+    if (mmap(shared_debug_counter_start, aligned_len, PROT_READ|PROT_WRITE,
+             MAP_SHARED|MAP_ANONYMOUS|MAP_FIXED, -1, 0) == MAP_FAILED) {
+        AIM_DIE("mmap failed: %s", strerror(errno));
+    }
+
+    memcpy(shared_debug_counter_start, copy, len);
+    aim_free(copy);
+}

--- a/targets/ivs/Makefile
+++ b/targets/ivs/Makefile
@@ -44,7 +44,7 @@ DEPENDMODULES := SocketManager OFConnectionManager OFStateManager OVSDriver \
                  Configuration loci indigo BigList BigHash ivs_common pipeline pipeline_standard tcam xbuf \
                  PPE IOF \
                  AIM murmur cjson OS uCli debug_counter timer_wheel bloom_filter BigRing minimatch action \
-                 stats pipeline_reflect
+                 stats pipeline_reflect shared_debug_counter
 
 ifndef NO_LUAJIT
 DEPENDMODULES += luajit pipeline_lua

--- a/targets/ivs/main.c
+++ b/targets/ivs/main.c
@@ -45,6 +45,7 @@
 #include <pipeline/pipeline.h>
 #include <malloc.h>
 #include <sys/resource.h>
+#include <shared_debug_counter/shared_debug_counter.h>
 
 #define AIM_LOG_MODULE_NAME ivs
 #include <AIM/aim_log.h>
@@ -373,6 +374,8 @@ aim_main(int argc, char* argv[])
     }
 
     AIM_LOG_MSG("Starting %s (%s) pid %d", program_version, AIM_STRINGIFY(BUILD_ID), getpid());
+
+    shared_debug_counter_init();
 
     /* Increase maximum number of file descriptors */
     struct rlimit rlim = {


### PR DESCRIPTION
Reviewer: @harshsin 

This module is a wrapper around debug counters which places them in shared
memory. This is necessary for debug counter updates from upcall processes to be
persistent and visible to the controller.

Also adds a few shared debug counters to upcall.c. We'll add more in the future.