### PR TITLE
OVSDriver: fix shifting when constructing DPID from MAC

### DIFF
--- a/modules/OVSDriver/module/src/ovs_driver.c
+++ b/modules/OVSDriver/module/src/ovs_driver.c
@@ -105,7 +105,7 @@ ind_ovs_dpid_set(const char *datapath_name)
 {
     bool found = false;
     uint8_t mac[6];
-    uint64_t dpid;
+    uint64_t dpid = 0;
     struct ifaddrs *ifaddr, *ifa;
 
     if (getifaddrs(&ifaddr) == -1) {
@@ -134,9 +134,14 @@ ind_ovs_dpid_set(const char *datapath_name)
         mac[5] = x >> 24;
     }
 
-    dpid = ((uint64_t)mac[0] << 40) | ((uint64_t)mac[1] << 32) | (mac[2] << 24) |
-        (mac[3] << 16) | (mac[4] << 8) | mac[5];
+    int i;
+    for (i = 0; i < sizeof(mac); i++) {
+        dpid <<= 8;
+        dpid |= mac[i];
+    }
+
     dpid |= (uint64_t)murmur_hash(datapath_name, strlen(datapath_name), 0x17ccd) << 48;
+
     indigo_core_dpid_set(dpid);
 
     freeifaddrs(ifaddr);


### PR DESCRIPTION
Reviewer: @harshsin

It's undefined behavior to left shift a value by more than its width. The 
mac[x] values are uint8_t, not uint32_t as the code assumed.