### PR TITLE
Packet trace

### DIFF
--- a/modules/Manifest.mk
+++ b/modules/Manifest.mk
@@ -32,3 +32,4 @@ action_BASEDIR := $(BASEDIR)/action
 stats_BASEDIR := $(BASEDIR)/stats
 pipeline_reflect_BASEDIR := $(BASEDIR)/pipeline_reflect
 shared_debug_counter_BASEDIR := $(BASEDIR)/shared_debug_counter
+packet_trace_BASEDIR := $(BASEDIR)/packet_trace

--- a/modules/OVSDriver/module/src/upcall.c
+++ b/modules/OVSDriver/module/src/upcall.c
@@ -36,6 +36,7 @@
 #include <sys/prctl.h>
 #include "SocketManager/socketmanager.h"
 #include "murmur/murmur.h"
+#include <packet_trace/packet_trace.h>
 
 #define DEFAULT_NUM_UPCALL_THREADS 4
 #define MAX_UPCALL_THREADS 16
@@ -571,6 +572,8 @@ ind_ovs_upcall_thread_init(struct ind_ovs_upcall_thread *thread)
             AIM_BITMAP_SET(fds, nl_socket_get_fd(port->notify_socket));
         }
     }
+
+    packet_trace_set_fd_bitmap(fds);
 
     /* Close all other file descriptors */
     for (i = 0; i < max_fds; i++) {

--- a/modules/action/module/src/action.c
+++ b/modules/action/module/src/action.c
@@ -21,6 +21,7 @@
 #include <byteswap.h>
 #include <linux/if_ether.h>
 #include <netlink/genl/genl.h>
+#include <packet_trace/packet_trace.h>
 
 static void commit_set_field_actions(struct action_context *ctx);
 
@@ -65,6 +66,8 @@ action_userspace(struct action_context *ctx, void *userdata, int datalen,
 {
     commit_set_field_actions(ctx);
 
+    packet_trace("action: userspace");
+
     struct nlattr *action_attr = nla_nest_start(ctx->msg, OVS_ACTION_ATTR_USERSPACE);
     nla_put_u32(ctx->msg, OVS_USERSPACE_ATTR_PID, netlink_port);
     nla_put(ctx->msg, OVS_USERSPACE_ATTR_USERDATA, datalen, userdata);
@@ -77,6 +80,7 @@ void
 action_output(struct action_context *ctx, uint32_t port_no)
 {
     commit_set_field_actions(ctx);
+    packet_trace("action: output port %u", port_no);
     nla_put_u32(ctx->msg, OVS_ACTION_ATTR_OUTPUT, port_no);
 }
 
@@ -84,13 +88,15 @@ void
 action_output_local(struct action_context *ctx)
 {
     commit_set_field_actions(ctx);
-    nla_put_u32(ctx->msg, OVS_ACTION_ATTR_OUTPUT, 0);
+    packet_trace("action: output local");
+    nla_put_u32(ctx->msg, OVS_ACTION_ATTR_OUTPUT, OVSP_LOCAL);
 }
 
 void
 action_output_in_port(struct action_context *ctx)
 {
     commit_set_field_actions(ctx);
+    packet_trace("action: output in_port");
     nla_put_u32(ctx->msg, OVS_ACTION_ATTR_OUTPUT, ctx->current_key.in_port);
     MASK(in_port);
 }
@@ -113,6 +119,7 @@ action_sample_to_userspace(struct action_context *ctx, void *userdata, int datal
                            uint32_t netlink_port, uint32_t probability)
 {
     commit_set_field_actions(ctx);
+    packet_trace("action: sample probability %u", probability);
 
     struct nlattr *sample_attr = nla_nest_start(ctx->msg, OVS_ACTION_ATTR_SAMPLE);
     nla_put_u32(ctx->msg, OVS_SAMPLE_ATTR_PROBABILITY, probability);
@@ -138,6 +145,7 @@ action_sample_to_userspace(struct action_context *ctx, void *userdata, int datal
 void
 action_set_eth_dst(struct action_context *ctx, of_mac_addr_t mac)
 {
+    packet_trace("action: set-eth-dst %{mac}", &mac);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_ETHERNET)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_ETHERNET);
         memcpy(ctx->current_key.ethernet.eth_dst, &mac, sizeof(of_mac_addr_t));
@@ -147,6 +155,7 @@ action_set_eth_dst(struct action_context *ctx, of_mac_addr_t mac)
 void
 action_set_eth_src(struct action_context *ctx, of_mac_addr_t mac)
 {
+    packet_trace("action: set-eth-src %{mac}", &mac);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_ETHERNET)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_ETHERNET);
         memcpy(ctx->current_key.ethernet.eth_src, &mac, sizeof(of_mac_addr_t));
@@ -156,6 +165,7 @@ action_set_eth_src(struct action_context *ctx, of_mac_addr_t mac)
 void
 action_set_eth_dst_scalar(struct action_context *ctx, uint32_t mac_lo, uint16_t mac_hi)
 {
+    packet_trace("action: set-eth-dst %02x%04x", mac_hi, mac_lo);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_ETHERNET)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_ETHERNET);
         unsigned char *buf = ctx->current_key.ethernet.eth_dst;
@@ -167,6 +177,7 @@ action_set_eth_dst_scalar(struct action_context *ctx, uint32_t mac_lo, uint16_t 
 void
 action_set_eth_src_scalar(struct action_context *ctx, uint32_t mac_lo, uint16_t mac_hi)
 {
+    packet_trace("action: set-eth-src %02x%04x", mac_hi, mac_lo);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_ETHERNET)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_ETHERNET);
         unsigned char *buf = ctx->current_key.ethernet.eth_src;
@@ -182,6 +193,7 @@ action_set_eth_src_scalar(struct action_context *ctx, uint32_t mac_lo, uint16_t 
 void
 action_set_vlan_vid(struct action_context *ctx, uint16_t vlan_vid)
 {
+    packet_trace("action: set-vlan-vid %u", vlan_vid);
     ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_VLAN);
     uint16_t cur_tci;
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_VLAN)) {
@@ -196,6 +208,7 @@ action_set_vlan_vid(struct action_context *ctx, uint16_t vlan_vid)
 void
 action_set_vlan_pcp(struct action_context *ctx, uint8_t vlan_pcp)
 {
+    packet_trace("action: set-vlan-pcp %u", vlan_pcp);
     ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_VLAN);
     uint16_t cur_tci;
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_VLAN)) {
@@ -210,6 +223,7 @@ action_set_vlan_pcp(struct action_context *ctx, uint8_t vlan_pcp)
 void
 action_pop_vlan(struct action_context *ctx)
 {
+    packet_trace("action: pop-vlan");
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_VLAN)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_VLAN);
         ATTR_BITMAP_CLEAR(ctx->current_key.populated, OVS_KEY_ATTR_VLAN);
@@ -219,6 +233,7 @@ action_pop_vlan(struct action_context *ctx)
 void
 action_push_vlan(struct action_context *ctx)
 {
+    packet_trace("action: push-vlan");
     if (!ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_VLAN)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_VLAN);
         ATTR_BITMAP_SET(ctx->current_key.populated, OVS_KEY_ATTR_VLAN);
@@ -230,6 +245,7 @@ void
 action_pop_vlan_raw(struct action_context *ctx)
 {
     commit_set_field_actions(ctx);
+    packet_trace("action: pop-vlan-raw");
     nla_put_flag(ctx->msg, OVS_ACTION_ATTR_POP_VLAN);
 }
 
@@ -237,6 +253,7 @@ void
 action_push_vlan_raw(struct action_context *ctx, uint16_t vlan_tci)
 {
     commit_set_field_actions(ctx);
+    packet_trace("action: push-vlan-raw 0x%x", vlan_tci);
 
     struct ovs_action_push_vlan vlan = {
         .vlan_tpid = htons(ETH_P_8021Q),
@@ -252,6 +269,7 @@ action_push_vlan_raw(struct action_context *ctx, uint16_t vlan_tci)
 void
 action_set_ipv4_dst(struct action_context *ctx, uint32_t ipv4)
 {
+    packet_trace("action: set-ipv4-dst %{ipv4a}", ipv4);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV4)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV4);
         ctx->current_key.ipv4.ipv4_dst = htonl(ipv4);
@@ -261,6 +279,7 @@ action_set_ipv4_dst(struct action_context *ctx, uint32_t ipv4)
 void
 action_set_ipv4_src(struct action_context *ctx, uint32_t ipv4)
 {
+    packet_trace("action: set-ipv4-src %{ipv4a}", ipv4);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV4)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV4);
         ctx->current_key.ipv4.ipv4_src = htonl(ipv4);
@@ -270,6 +289,7 @@ action_set_ipv4_src(struct action_context *ctx, uint32_t ipv4)
 void
 action_set_ipv4_dscp(struct action_context *ctx, uint8_t ip_dscp)
 {
+    packet_trace("action: set-ipv4-dscp %u", ip_dscp);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV4)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV4);
         ctx->current_key.ipv4.ipv4_tos &= (uint8_t)(~IP_DSCP_MASK);
@@ -280,6 +300,7 @@ action_set_ipv4_dscp(struct action_context *ctx, uint8_t ip_dscp)
 void
 action_set_ipv4_ecn(struct action_context *ctx, uint8_t ip_ecn)
 {
+    packet_trace("action: set-ipv4-ecn %u", ip_ecn);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV4)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV4);
         ctx->current_key.ipv4.ipv4_tos &= (uint8_t)(~IP_ECN_MASK);
@@ -290,6 +311,7 @@ action_set_ipv4_ecn(struct action_context *ctx, uint8_t ip_ecn)
 void
 action_set_ipv4_ttl(struct action_context *ctx, uint8_t ttl)
 {
+    packet_trace("action: set-ipv4-ttl %u", ttl);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV4)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV4);
         ctx->current_key.ipv4.ipv4_ttl = ttl;
@@ -303,6 +325,7 @@ action_set_ipv4_ttl(struct action_context *ctx, uint8_t ttl)
 void
 action_set_ipv6_dst(struct action_context *ctx, of_ipv6_t ipv6)
 {
+    packet_trace("action: set-ipv6-dst %{ipv6a}", &ipv6);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV6)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV6);
         memcpy(ctx->current_key.ipv6.ipv6_dst, &ipv6, sizeof(of_ipv6_t));
@@ -312,6 +335,7 @@ action_set_ipv6_dst(struct action_context *ctx, of_ipv6_t ipv6)
 void
 action_set_ipv6_src(struct action_context *ctx, of_ipv6_t ipv6)
 {
+    packet_trace("action: set-ipv6-src %{ipv6a}", &ipv6);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV6)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV6);
         memcpy(ctx->current_key.ipv6.ipv6_src, &ipv6, sizeof(of_ipv6_t));
@@ -321,6 +345,7 @@ action_set_ipv6_src(struct action_context *ctx, of_ipv6_t ipv6)
 void
 action_set_ipv6_dscp(struct action_context *ctx, uint8_t ip_dscp)
 {
+    packet_trace("action: set-ipv6-dscp %u", ip_dscp);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV6)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV6);
         ctx->current_key.ipv6.ipv6_tclass &= (uint8_t)(~IP_DSCP_MASK);
@@ -331,6 +356,7 @@ action_set_ipv6_dscp(struct action_context *ctx, uint8_t ip_dscp)
 void
 action_set_ipv6_ecn(struct action_context *ctx, uint8_t ip_ecn)
 {
+    packet_trace("action: set-ipv6-ecn %u", ip_ecn);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV6)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV6);
         ctx->current_key.ipv6.ipv6_tclass &= (uint8_t)(~IP_ECN_MASK);
@@ -341,6 +367,7 @@ action_set_ipv6_ecn(struct action_context *ctx, uint8_t ip_ecn)
 void
 action_set_ipv6_ttl(struct action_context *ctx, uint8_t ttl)
 {
+    packet_trace("action: set-ipv6-ttl %u", ttl);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV6)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV6);
         ctx->current_key.ipv6.ipv6_hlimit = ttl;
@@ -350,6 +377,7 @@ action_set_ipv6_ttl(struct action_context *ctx, uint8_t ttl)
 void
 action_set_ipv6_flabel(struct action_context *ctx, uint32_t flabel)
 {
+    packet_trace("action: set-ipv6-flabel %u", flabel);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV6)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV6);
         ctx->current_key.ipv6.ipv6_label = htonl(flabel);
@@ -363,6 +391,7 @@ action_set_ipv6_flabel(struct action_context *ctx, uint32_t flabel)
 void
 action_set_tcp_src(struct action_context *ctx, uint16_t tcp_src)
 {
+    packet_trace("action: set-tcp-src %u", tcp_src);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_TCP)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_TCP);
         ctx->current_key.tcp.tcp_src = htons(tcp_src);
@@ -372,6 +401,7 @@ action_set_tcp_src(struct action_context *ctx, uint16_t tcp_src)
 void
 action_set_tcp_dst(struct action_context *ctx, uint16_t tcp_dst)
 {
+    packet_trace("action: set-tcp-dst %u", tcp_dst);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_TCP)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_TCP);
         ctx->current_key.tcp.tcp_dst = htons(tcp_dst);
@@ -385,6 +415,7 @@ action_set_tcp_dst(struct action_context *ctx, uint16_t tcp_dst)
 void
 action_set_udp_src(struct action_context *ctx, uint16_t udp_src)
 {
+    packet_trace("action: set-udp-src %u", udp_src);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_UDP)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_UDP);
         ctx->current_key.udp.udp_src = htons(udp_src);
@@ -394,6 +425,7 @@ action_set_udp_src(struct action_context *ctx, uint16_t udp_src)
 void
 action_set_udp_dst(struct action_context *ctx, uint16_t udp_dst)
 {
+    packet_trace("action: set-udp-dst %u", udp_dst);
     if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_UDP)) {
         ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_UDP);
         ctx->current_key.udp.udp_dst = htons(udp_dst);
@@ -407,6 +439,7 @@ action_set_udp_dst(struct action_context *ctx, uint16_t udp_dst)
 void
 action_set_priority(struct action_context *ctx, uint32_t priority)
 {
+    packet_trace("action: set-priority %u", priority);
     ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_PRIORITY);
     ctx->current_key.priority = priority;
 }

--- a/modules/packet_trace/.gitignore
+++ b/modules/packet_trace/.gitignore
@@ -1,0 +1,1 @@
+/packet_trace.mk

--- a/modules/packet_trace/module/inc/packet_trace/packet_trace.h
+++ b/modules/packet_trace/module/inc/packet_trace/packet_trace.h
@@ -18,10 +18,36 @@
  ****************************************************************/
 
 /*
- *
+ * This module allows the user to see logs from the forwarding pipeline for a
+ * subset of packets.
  */
 
 #ifndef PACKET_TRACE_H
 #define PACKET_TRACE_H
+
+#include <stdint.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <AIM/aim_bitmap.h>
+
+void packet_trace_init(const char *name);
+
+void packet_trace_begin(uint32_t in_port);
+void packet_trace_end(void);
+void packet_trace_internal(const char *fmt, va_list vargs);
+void packet_trace_set_fd_bitmap(aim_bitmap_t *bitmap);
+
+extern bool packet_trace_enabled;
+
+static inline void
+packet_trace(const char *fmt, ...)
+{
+    if (__builtin_expect(packet_trace_enabled, false)) {
+        va_list vargs;
+        va_start(vargs, fmt);
+        packet_trace_internal(fmt, vargs);
+        va_end(vargs);
+    }
+}
 
 #endif

--- a/modules/packet_trace/module/inc/packet_trace/packet_trace.h
+++ b/modules/packet_trace/module/inc/packet_trace/packet_trace.h
@@ -1,0 +1,27 @@
+/****************************************************************
+ *
+ *        Copyright 2015, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+/*
+ *
+ */
+
+#ifndef PACKET_TRACE_H
+#define PACKET_TRACE_H
+
+#endif

--- a/modules/packet_trace/module/make.mk
+++ b/modules/packet_trace/module/make.mk
@@ -20,3 +20,4 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 packet_trace_INCLUDES := -I $(THIS_DIR)inc
 packet_trace_INTERNAL_INCLUDES := -I $(THIS_DIR)src
+packet_trace_DEPENDMODULE_ENTRIES := init:packet_trace

--- a/modules/packet_trace/module/make.mk
+++ b/modules/packet_trace/module/make.mk
@@ -1,0 +1,22 @@
+################################################################
+#
+#        Copyright 2015, Big Switch Networks, Inc.
+#
+# Licensed under the Eclipse Public License, Version 1.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#        http://www.eclipse.org/legal/epl-v10.html
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the
+# License.
+#
+################################################################
+
+THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+packet_trace_INCLUDES := -I $(THIS_DIR)inc
+packet_trace_INTERNAL_INCLUDES := -I $(THIS_DIR)src

--- a/modules/packet_trace/module/src/make.mk
+++ b/modules/packet_trace/module/src/make.mk
@@ -1,0 +1,22 @@
+################################################################
+#
+#        Copyright 2015, Big Switch Networks, Inc.
+#
+# Licensed under the Eclipse Public License, Version 1.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#        http://www.eclipse.org/legal/epl-v10.html
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the
+# License.
+#
+################################################################
+
+LIBRARY := packet_trace
+$(LIBRARY)_SUBDIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(BUILDER)/lib.mk

--- a/modules/packet_trace/module/src/packet_trace.c
+++ b/modules/packet_trace/module/src/packet_trace.c
@@ -25,6 +25,7 @@
 #include <sys/socket.h>
 #include <SocketManager/socketmanager.h>
 #include <errno.h>
+#include <fcntl.h>
 
 #define AIM_LOG_MODULE_NAME packet_trace
 #include <AIM/aim_log.h>
@@ -186,6 +187,11 @@ listen_callback(
     if ((fd = accept(listen_socket, NULL, NULL)) < 0) {
         AIM_LOG_ERROR("Failed to accept on packet_trace socket: %s", strerror(errno));
         return;
+    }
+
+    int soc_flags = fcntl(fd, F_GETFL, 0);
+    if (soc_flags == -1 || fcntl(fd, F_SETFL, soc_flags | O_NONBLOCK) == -1) {
+        AIM_LOG_WARN("Failed to set non-blocking flag for socket: %s", strerror(errno));
     }
 
     struct client *client = aim_zmalloc(sizeof(*client));

--- a/modules/packet_trace/module/src/packet_trace.c
+++ b/modules/packet_trace/module/src/packet_trace.c
@@ -125,7 +125,7 @@ packet_trace_end(void)
     }
 
     char *buf = aim_pvs_buffer_get(pvs);
-    int len = aim_pvs_buffer_size(pvs);
+    int len = strlen(buf);
     aim_pvs_buffer_reset(pvs);
 
     list_links_t *cur;

--- a/modules/packet_trace/module/src/packet_trace.c
+++ b/modules/packet_trace/module/src/packet_trace.c
@@ -227,6 +227,7 @@ listen_callback(
     indigo_error_t rv = ind_soc_socket_register(fd, client_callback, client);
     if (rv < 0) {
         AIM_LOG_ERROR("Failed to register packet_trace client socket: %s", indigo_strerror(rv));
+        destroy_client(client);
         return;
     }
 }

--- a/modules/packet_trace/module/src/packet_trace.c
+++ b/modules/packet_trace/module/src/packet_trace.c
@@ -26,6 +26,7 @@
 #include <SocketManager/socketmanager.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <ivs/ivs.h>
 
 #define AIM_LOG_MODULE_NAME packet_trace
 #include <AIM/aim_log.h>
@@ -272,6 +273,7 @@ destroy_client(struct client *client)
     close(client->fd);
     list_remove(&client->links);
     aim_free(client);
+    ind_ovs_barrier_defer_revalidation(-1);
 }
 
 static void
@@ -296,6 +298,7 @@ process_add_command(struct client *client, const char **argv, int argc)
             reply(client, "invalid port number\n");
         } else {
             AIM_BITMAP_SET(&client->ports, port);
+            ind_ovs_barrier_defer_revalidation(-1);
         }
     } else if (!strcmp(argv[0], "all")) {
         if (argc != 1) {
@@ -303,6 +306,7 @@ process_add_command(struct client *client, const char **argv, int argc)
             return;
         }
         AIM_BITMAP_SET_ALL(&client->ports);
+        ind_ovs_barrier_defer_revalidation(-1);
     } else {
         reply(client, "unexpected filter type\n");
     }

--- a/modules/packet_trace/module/src/packet_trace.c
+++ b/modules/packet_trace/module/src/packet_trace.c
@@ -18,3 +18,118 @@
  ****************************************************************/
 
 #include <packet_trace/packet_trace.h>
+#include <AIM/aim.h>
+#include <AIM/aim_list.h>
+#include <unistd.h>
+
+#define AIM_LOG_MODULE_NAME packet_trace
+#include <AIM/aim_log.h>
+
+AIM_LOG_STRUCT_DEFINE(AIM_LOG_OPTIONS_DEFAULT, AIM_LOG_BITS_DEFAULT, NULL, 0);
+
+#define MAX_PORTS 1024
+
+struct client {
+    struct list_links links;
+    int fd;
+    aim_bitmap_t ports;
+};
+
+struct packet {
+    uint32_t in_port;
+};
+
+static bool check_subscribed(struct client *client);
+
+bool packet_trace_enabled;
+static LIST_DEFINE(clients);
+static aim_pvs_t *pvs;
+static struct packet packet;
+
+void
+packet_trace_init(const char *name)
+{
+    pvs = aim_pvs_buffer_create();
+
+    struct client *client = aim_zmalloc(sizeof(*client));
+    client->fd = STDERR_FILENO;
+    aim_bitmap_alloc(&client->ports, MAX_PORTS);
+    list_push(&clients, &client->links);
+
+    /* TODO allow user to select subset of ports */
+    AIM_BITMAP_SET_ALL(&client->ports);
+
+    /* TODO create and register listening socket */
+}
+
+void
+packet_trace_finish(void)
+{
+    /* TODO cleanup socket */
+}
+
+void
+packet_trace_begin(uint32_t in_port)
+{
+    packet.in_port = in_port;
+
+    packet_trace_enabled = false;
+
+    list_links_t *cur;
+    LIST_FOREACH(&clients, cur) {
+        struct client *client = container_of(cur, links, struct client);
+        if (check_subscribed(client)) {
+            packet_trace_enabled = true;
+            break;
+        }
+    }
+
+    packet_trace("--------------------------------------------------------------");
+}
+
+void
+packet_trace_end(void)
+{
+    if (!packet_trace_enabled) {
+        return;
+    }
+
+    char *buf = aim_pvs_buffer_get(pvs);
+    int len = aim_pvs_buffer_size(pvs);
+    aim_pvs_buffer_reset(pvs);
+
+    list_links_t *cur;
+    LIST_FOREACH(&clients, cur) {
+        struct client *client = container_of(cur, links, struct client);
+        if (!check_subscribed(client)) {
+            continue;
+        }
+        AIM_LOG_TRACE("writing to client %d (%d bytes)", client->fd, len);
+        int written = 0;
+        while (written < len) {
+            int c = write(client->fd, buf+written, len-written);
+            if (c < 0) {
+                break;
+            } else if (c == 0) {
+                break;
+            } else {
+                written += c;
+            }
+        }
+    }
+
+    aim_free(buf);
+}
+
+void
+packet_trace_internal(const char *fmt, va_list vargs)
+{
+    aim_vprintf(pvs, fmt, vargs);
+    aim_printf(pvs, "\n");
+}
+
+static bool
+check_subscribed(struct client *client)
+{
+    return AIM_BITMAP_GET(&client->ports, packet.in_port);
+}

--- a/modules/packet_trace/module/src/packet_trace.c
+++ b/modules/packet_trace/module/src/packet_trace.c
@@ -1,0 +1,20 @@
+/****************************************************************
+ *
+ *        Copyright 2015, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+#include <packet_trace/packet_trace.h>

--- a/modules/pipeline/module/src/pipeline.c
+++ b/modules/pipeline/module/src/pipeline.c
@@ -138,7 +138,7 @@ pipeline_process(struct ind_ovs_parsed_key *key,
         if (ind_ovs_uplink_check(key->in_port)) {
             mask->vlan = -1;
             if (VLAN_VID(ntohs(key->vlan)) == ind_ovs_inband_vlan) {
-                AIM_LOG_VERBOSE("Sending in-band management packet from uplink to internal port");
+                packet_trace("Sending in-band management packet from uplink to internal port");
                 action_pop_vlan(actx);
                 action_output(actx, IVS_INBAND_PORT);
                 packet_trace_end();
@@ -146,7 +146,7 @@ pipeline_process(struct ind_ovs_parsed_key *key,
             }
             /* fall through */
         } else if (key->in_port == IVS_INBAND_PORT) {
-            AIM_LOG_VERBOSE("Sending in-band management packet from internal port to uplink");
+            packet_trace("Sending in-band management packet from internal port to uplink");
             uint32_t port = ind_ovs_uplink_first();
             if (port != OF_PORT_DEST_NONE) {
                 action_push_vlan(actx);
@@ -156,7 +156,7 @@ pipeline_process(struct ind_ovs_parsed_key *key,
                 }
                 action_output(actx, port);
             } else {
-                AIM_LOG_VERBOSE("No available uplink");
+                packet_trace("No available uplink");
             }
             packet_trace_end();
             return INDIGO_ERROR_NONE;
@@ -164,8 +164,9 @@ pipeline_process(struct ind_ovs_parsed_key *key,
         /* fall through */
     }
 
+    indigo_error_t rv = current_pipeline->ops->process(key, mask, stats, actx);
     packet_trace_end();
-    return current_pipeline->ops->process(key, mask, stats, actx);
+    return rv;
 }
 
 void

--- a/modules/pipeline/module/src/pipeline.c
+++ b/modules/pipeline/module/src/pipeline.c
@@ -23,6 +23,7 @@
 
 #include <ivs/ivs.h>
 #include <loci/loci.h>
+#include <packet_trace/packet_trace.h>
 
 #define AIM_LOG_MODULE_NAME pipeline
 #include <AIM/aim_log.h>
@@ -127,17 +128,20 @@ pipeline_process(struct ind_ovs_parsed_key *key,
 {
     AIM_TRUE_OR_DIE(current_pipeline != NULL);
 
+    mask->in_port = -1;
+    packet_trace_begin(key->in_port);
+
     mask->populated = key->populated;
     ATTR_BITMAP_SET(mask->populated, OVS_KEY_ATTR_ETHERTYPE);
 
     if (ind_ovs_inband_vlan != VLAN_INVALID) {
-        mask->in_port = -1;
         if (ind_ovs_uplink_check(key->in_port)) {
             mask->vlan = -1;
             if (VLAN_VID(ntohs(key->vlan)) == ind_ovs_inband_vlan) {
                 AIM_LOG_VERBOSE("Sending in-band management packet from uplink to internal port");
                 action_pop_vlan(actx);
                 action_output(actx, IVS_INBAND_PORT);
+                packet_trace_end();
                 return INDIGO_ERROR_NONE;
             }
             /* fall through */
@@ -154,11 +158,13 @@ pipeline_process(struct ind_ovs_parsed_key *key,
             } else {
                 AIM_LOG_VERBOSE("No available uplink");
             }
+            packet_trace_end();
             return INDIGO_ERROR_NONE;
         }
         /* fall through */
     }
 
+    packet_trace_end();
     return current_pipeline->ops->process(key, mask, stats, actx);
 }
 

--- a/modules/pipeline_standard/module/src/action.c
+++ b/modules/pipeline_standard/module/src/action.c
@@ -26,6 +26,7 @@
 #include <action/action.h>
 #include <indigo/of_state_manager.h>
 #include <pipeline/pipeline.h>
+#include <packet_trace/packet_trace.h>
 #include "group.h"
 
 #define AIM_LOG_MODULE_NAME pipeline_standard
@@ -115,6 +116,7 @@ pipeline_standard_translate_actions(
             action_set_ipv6_ecn(ctx, *XBUF_PAYLOAD(attr, uint8_t));
             break;
         case IND_OVS_ACTION_DEC_NW_TTL:
+            packet_trace("action: dec-ttl");
             /* Special cased because it can drop the packet */
             if (ATTR_BITMAP_TEST(ctx->current_key.populated, OVS_KEY_ATTR_IPV4)) {
                 ATTR_BITMAP_SET(ctx->modified_attrs, OVS_KEY_ATTR_IPV4);
@@ -196,7 +198,10 @@ process_group(
     struct action_context *ctx, struct group *group,
     uint32_t hash, struct xbuf *stats)
 {
+    packet_trace("group %u type %u", group->id, group->type);
+
     if (group->value.num_buckets == 0) {
+        packet_trace("empty group");
         return;
     }
 

--- a/modules/pipeline_standard/module/src/cfr.c
+++ b/modules/pipeline_standard/module/src/cfr.c
@@ -21,6 +21,7 @@
 #include <byteswap.h>
 #include <linux/if_ether.h>
 #include <arpa/inet.h>
+#include <packet_trace/packet_trace.h>
 #include "cfr.h"
 
 #define AIM_LOG_MODULE_NAME pipeline_standard
@@ -240,6 +241,37 @@ pipeline_standard_dump_cfr(const struct pipeline_standard_cfr *cfr)
     }
 
 #define output(fmt, ...) AIM_LOG_VERBOSE("  " fmt, ##__VA_ARGS__)
+
+    output("dl_dst=%{mac}", cfr->dl_dst);
+    output("dl_src=%{mac}", cfr->dl_src);
+    output("in_port=%u", cfr->in_port);
+    output("dl_type=0x%04x", ntohs(cfr->dl_type));
+    output("dl_vlan=0x%04x", ntohs(cfr->dl_vlan));
+    output("nw_tos=0x%x", cfr->nw_tos);
+    output("nw_proto=0x%x", cfr->nw_proto);
+    output("nw_src=%{ipv4a}", ntohl(cfr->nw_src));
+    output("nw_dst=%{ipv4a}", ntohl(cfr->nw_dst));
+    output("tp_src=%u", ntohs(cfr->tp_src));
+    output("tp_dst=%u", ntohs(cfr->tp_dst));
+
+    char src[INET6_ADDRSTRLEN], dst[INET6_ADDRSTRLEN];
+    inet_ntop(AF_INET6, cfr->ipv6_src, src, INET6_ADDRSTRLEN);
+    inet_ntop(AF_INET6, cfr->ipv6_dst, dst, INET6_ADDRSTRLEN);
+    output("ipv6_src=%s", src);
+    output("ipv6_dst=%s", dst);
+
+#undef output
+}
+
+void
+pipeline_standard_trace_cfr(const struct pipeline_standard_cfr *cfr)
+{
+    if (!packet_trace_enabled) {
+        /* Exit early if we wouldn't log anything */
+        return;
+    }
+
+#define output(fmt, ...) packet_trace("  " fmt, ##__VA_ARGS__)
 
     output("dl_dst=%{mac}", cfr->dl_dst);
     output("dl_src=%{mac}", cfr->dl_src);

--- a/modules/pipeline_standard/module/src/cfr.h
+++ b/modules/pipeline_standard/module/src/cfr.h
@@ -42,4 +42,7 @@ void pipeline_standard_match_to_cfr(const of_match_t *match, struct pipeline_sta
 /* Log a readable version of the CFR */
 void pipeline_standard_dump_cfr(const struct pipeline_standard_cfr *cfr);
 
+/* packet_trace a readable version of the CFR */
+void pipeline_standard_trace_cfr(const struct pipeline_standard_cfr *cfr);
+
 #endif

--- a/targets/ivs-ctl/ivs-ctl.8
+++ b/targets/ivs-ctl/ivs-ctl.8
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH IVS-CTL 8 "May  24, 2013"
+.TH IVS-CTL 8 "March 25, 2015"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -23,6 +23,9 @@ ivs-ctl \- utility for configuring Indigo Virtual Switch
 \fB ivs-ctl add-port\fR \fIINTERFACE\fR
 \fB ivs-ctl add-internal-port\fR \fIINTERFACE\fR
 \fB ivs-ctl del-port\fR \fIINTERFACE\fR
+\fB ivs-ctl dump-flows\fR
+\fB ivs-ctl list-ports\fR
+\fB ivs-ctl trace\fR
 .SH DESCRIPTION
 The \fBivs-ctl\fP command can be used to view and modify the \fBivs\fP virtual
 switch datapath.
@@ -37,6 +40,12 @@ The \fBadd-internal-port\fP command creates a Linux interface connected to
 the datapath. This interface can have an IP address assigned to
 it and can generally be used like a normal netdev, but traffic to and from it
 will flow through the datapath.
+.PP
+The \fBdump-flows\fP command shows the contents of the kernel flowtable.
+.PP
+The \fBlist-ports\fP command shows the names of each attached port, one per line.
+.PP
+The \fBtrace\fP command explains the forwarding decision for each new flow.
 .PP
 .SH AUTHOR
 ivs was written by the Indigo community <http://www.openflowhub.org/display/Indigo>.

--- a/targets/ivs/Makefile
+++ b/targets/ivs/Makefile
@@ -44,7 +44,7 @@ DEPENDMODULES := SocketManager OFConnectionManager OFStateManager OVSDriver \
                  Configuration loci indigo BigList BigHash ivs_common pipeline pipeline_standard tcam xbuf \
                  PPE IOF \
                  AIM murmur cjson OS uCli debug_counter timer_wheel bloom_filter BigRing minimatch action \
-                 stats pipeline_reflect shared_debug_counter
+                 stats pipeline_reflect shared_debug_counter packet_trace
 
 ifndef NO_LUAJIT
 DEPENDMODULES += luajit pipeline_lua

--- a/targets/ivs/main.c
+++ b/targets/ivs/main.c
@@ -48,6 +48,7 @@
 #include <shared_debug_counter/shared_debug_counter.h>
 #include <sys/prctl.h>
 #include <execinfo.h>
+#include <packet_trace/packet_trace.h>
 
 #define AIM_LOG_MODULE_NAME ivs
 #include <AIM/aim_log.h>
@@ -723,6 +724,8 @@ aim_main(int argc, char* argv[])
 
     /* Start handling upcalls */
     ind_ovs_enable();
+
+    packet_trace_init(datapath_name);
 
     ind_soc_select_and_run(-1);
 


### PR DESCRIPTION
Reviewer: @harshsin 

This pull request adds a new "trace" command to ivs-ctl. With this command you can watch the forwarding decisions being made in real time. This is extremely useful for debugging issues where packets aren't being forwarded as expected.

This code is designed to have minimal performance impact when no trace clients are connected or when no filters match a given packet. It should be easy to add new types of filters besides just port number.

Usage:

    ivs-ctl trace port 6 # Show all packets from port 6
    ivs-ctl trace # Show all packets