### PR TITLE
OVSDriver: reuse kernel datapath

### DIFF
--- a/modules/OVSDriver/module/src/ovs_driver.c
+++ b/modules/OVSDriver/module/src/ovs_driver.c
@@ -55,8 +55,6 @@ struct ind_ovs_pktin_socket ind_ovs_pktout_soc;
 static int
 ind_ovs_create_datapath(const char *name)
 {
-    int ret;
-
     assert(ind_ovs_dp_ifindex == 0);
     assert(strlen(name) < 256);
 
@@ -76,7 +74,7 @@ ind_ovs_create_datapath(const char *name)
         struct nl_msg *msg = ind_ovs_create_nlmsg(ovs_datapath_family, OVS_DP_CMD_NEW);
         nla_put_string(msg, OVS_DP_ATTR_NAME, name);
         nla_put_u32(msg, OVS_DP_ATTR_UPCALL_PID, 0);
-        ret = ind_ovs_transact(msg);
+        int ret = ind_ovs_transact(msg);
         if (ret != 0) {
             return ret;
         }
@@ -90,7 +88,7 @@ ind_ovs_create_datapath(const char *name)
         setup_inband();
     }
 
-    return ret;
+    return 0;
 }
 
 /*

--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -198,6 +198,7 @@ void ind_ovs_upcall_respawn(void);
 
 /* Interface of the multicast submodule */
 void ind_ovs_multicast_init(void);
+void ind_ovs_multicast_resync(void);
 
 /* Interface of the group submodule */
 void ind_ovs_group_module_init(void);

--- a/modules/OVSDriver/module/src/vport.c
+++ b/modules/OVSDriver/module/src/vport.c
@@ -175,6 +175,10 @@ indigo_error_t indigo_port_interface_add(
     assert(of_port < IND_OVS_MAX_PORTS || of_port == OF_PORT_DEST_NONE);
     assert(strlen(port_name) < 256);
 
+    if (ind_ovs_port_lookup_by_name(port_name)) {
+        return INDIGO_ERROR_NONE;
+    }
+
     struct nl_msg *msg = ind_ovs_create_nlmsg(ovs_vport_family, OVS_VPORT_CMD_NEW);
     nla_put_u32(msg, OVS_VPORT_ATTR_TYPE, OVS_VPORT_TYPE_NETDEV);
     nla_put_string(msg, OVS_VPORT_ATTR_NAME, port_name);
@@ -191,6 +195,10 @@ ind_ovs_port_add_internal(const char *port_name)
 {
     if (strlen(port_name) >= 256) {
         return INDIGO_ERROR_PARAM;
+    }
+
+    if (ind_ovs_port_lookup_by_name(port_name)) {
+        return INDIGO_ERROR_NONE;
     }
 
     struct nl_msg *msg = ind_ovs_create_nlmsg(ovs_vport_family, OVS_VPORT_CMD_NEW);
@@ -248,6 +256,10 @@ ind_ovs_port_added(uint32_t port_no, const char *ifname,
     }
 
     debug_counter_inc(&add);
+
+    if (port_no == OVSP_LOCAL) {
+        ifname = "local";
+    }
 
     struct ind_ovs_port *port = aim_zmalloc(sizeof(*port));
 

--- a/targets/ivs/main.c
+++ b/targets/ivs/main.c
@@ -488,6 +488,15 @@ aim_main(int argc, char* argv[])
         AIM_LOG_WARN("Failed to increase RLIMIT_NOFILE");
     }
 
+    /* Add uplink names from command line */
+    {
+        biglist_t *element;
+        char *str;
+        BIGLIST_FOREACH_DATA(element, uplinks, char *, str) {
+            ind_ovs_uplink_add(str);
+        }
+    }
+
     /* Initialize all modules */
 
     if (ind_soc_init(&soc_cfg) < 0) {
@@ -575,7 +584,6 @@ aim_main(int argc, char* argv[])
             if (indigo_port_interface_add(str, port_no, NULL)) {
                 AIM_LOG_ERROR("Failed to add uplink %s", str);
             }
-            ind_ovs_uplink_add(str);
             port_no++;
         }
     }


### PR DESCRIPTION
Reviewer: @harshsin

This preserves connected ports across vswitch restarts. Kernel flows are 
deleted, but future work will preserve them too.