### PR TITLE
OVSDriver: sticky uplinks

### DIFF
--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -186,7 +186,8 @@ struct ind_ovs_port *ind_ovs_port_lookup_by_name(const char *ifname);
 /* Interface of the uplink submodule */
 bool ind_ovs_uplink_check_by_name(const char *name);
 bool ind_ovs_uplink_check(of_port_no_t port_no);
-of_port_no_t ind_ovs_uplink_first(void);
+of_port_no_t ind_ovs_uplink_select(void);
+void ind_ovs_uplink_reselect(void);
 
 /* Interface of the upcall submodule */
 void ind_ovs_upcall_init(void);

--- a/modules/ivs/module/inc/ivs/ivs.h
+++ b/modules/ivs/module/inc/ivs/ivs.h
@@ -152,7 +152,7 @@ struct stats_handle *ind_ovs_tx_vlan_stats_select(uint16_t vlan_vid);
 struct ind_ovs_port_counters *ind_ovs_port_stats_select(of_port_no_t port_no);
 void ind_ovs_barrier_defer_revalidation(indigo_cxn_id_t cxn_id);
 bool ind_ovs_uplink_check(of_port_no_t port_no);
-of_port_no_t ind_ovs_uplink_first(void);
+of_port_no_t ind_ovs_uplink_select(void);
 extern uint16_t ind_ovs_inband_vlan;
 uint32_t ind_ovs_pktin_socket_netlink_port(struct ind_ovs_pktin_socket *soc);
 void ind_ovs_pktin_socket_register(struct ind_ovs_pktin_socket *soc,

--- a/modules/pipeline/module/src/pipeline.c
+++ b/modules/pipeline/module/src/pipeline.c
@@ -143,7 +143,7 @@ pipeline_process(struct ind_ovs_parsed_key *key,
             /* fall through */
         } else if (key->in_port == IVS_INBAND_PORT) {
             AIM_LOG_VERBOSE("Sending in-band management packet from internal port to uplink");
-            uint32_t port = ind_ovs_uplink_first();
+            uint32_t port = ind_ovs_uplink_select();
             if (port != OF_PORT_DEST_NONE) {
                 action_push_vlan(actx);
                 action_set_vlan_vid(actx, ind_ovs_inband_vlan);


### PR DESCRIPTION
Reviewer: @harshsin

The previous algorithm for picking an uplink iterated through all ports to
find the first live one with the uplink bit set. This was more expensive than 
necessary, but the main problem is that IFF_RUNNING doesn't mean that the 
switch on the other side is ready to forward packets. We don't want to move
our inband OpenFlow connections from a working uplink to a potentially
not-working one.

This change runs the uplink selection algorithm on port events instead of for 
every packet. It will try to keep the same uplink as long as it's still live.