### PR TITLE
cleanup getting the vport MAC address

### DIFF
--- a/modules/OVSDriver/module/src/multicast.c
+++ b/modules/OVSDriver/module/src/multicast.c
@@ -22,11 +22,7 @@
 #include "indigo/port_manager.h"
 #include "indigo/of_state_manager.h"
 #include "indigo/types.h"
-#include <linux/if_ether.h>
-#include <linux/if_packet.h>
-#include <ifaddrs.h>
 #include <stdbool.h>
-#include <sys/epoll.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -61,24 +57,8 @@ ind_ovs_handle_vport_multicast(struct nlmsghdr *nlh)
     assert(attrs[OVS_VPORT_ATTR_TYPE]);
     enum ovs_vport_type type = nla_get_u32(attrs[OVS_VPORT_ATTR_TYPE]);
 
-    of_mac_addr_t mac_addr = of_mac_addr_all_zeros;
-    struct ifaddrs *ifaddr, *ifa;
-    if (getifaddrs(&ifaddr) != -1) {
-        for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
-            if (!strcmp(ifname, ifa->ifa_name)) {
-                struct sockaddr_ll *sa = (struct sockaddr_ll *)ifa->ifa_addr;
-                if (sa != NULL && sa->sll_family == AF_PACKET) {
-                    memcpy(mac_addr.addr, &sa->sll_addr, OF_MAC_ADDR_BYTES);
-                    LOG_VERBOSE("Using MAC from interface %s", ifa->ifa_name);
-                    break;
-                }
-            }
-        }
-    }
-    freeifaddrs(ifaddr);
-
     if (gnlh->cmd == OVS_VPORT_CMD_NEW) {
-        ind_ovs_port_added(port_no, ifname, type, mac_addr);
+        ind_ovs_port_added(port_no, ifname, type);
     } else if (gnlh->cmd == OVS_VPORT_CMD_DEL) {
         ind_ovs_port_deleted(port_no);
     }

--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -178,7 +178,7 @@ void ind_ovs_kflow_module_init(void);
 /* Management of the port set */
 void ind_ovs_port_init(void);
 void ind_ovs_port_finish(void);
-void ind_ovs_port_added(uint32_t port_no, const char *ifname, enum ovs_vport_type type, of_mac_addr_t mac_addr);
+void ind_ovs_port_added(uint32_t port_no, const char *ifname, enum ovs_vport_type type);
 void ind_ovs_port_deleted(uint32_t port_no);
 struct ind_ovs_port *ind_ovs_port_lookup(of_port_no_t port_no);
 struct ind_ovs_port *ind_ovs_port_lookup_by_name(const char *ifname);

--- a/modules/OVSDriver/module/src/vport.c
+++ b/modules/OVSDriver/module/src/vport.c
@@ -26,6 +26,9 @@
 #include <errno.h>
 #include <netlink/cache.h>
 #include <netlink/route/link.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <ifaddrs.h>
 
 #ifndef _LINUX_IF_H
 /* Some versions of libnetlink include linux/if.h, which conflicts with net/if.h. */
@@ -246,7 +249,7 @@ indigo_port_interface_list_destroy(indigo_port_info_t* list)
 
 void
 ind_ovs_port_added(uint32_t port_no, const char *ifname,
-                   enum ovs_vport_type type, of_mac_addr_t mac_addr)
+                   enum ovs_vport_type type)
 {
     indigo_error_t err;
 
@@ -256,6 +259,22 @@ ind_ovs_port_added(uint32_t port_no, const char *ifname,
     }
 
     debug_counter_inc(&add);
+
+    of_mac_addr_t mac_addr = of_mac_addr_all_zeros;
+    struct ifaddrs *ifaddr, *ifa;
+    if (getifaddrs(&ifaddr) != -1) {
+        for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+            if (!strcmp(ifname, ifa->ifa_name)) {
+                struct sockaddr_ll *sa = (struct sockaddr_ll *)ifa->ifa_addr;
+                if (sa != NULL && sa->sll_family == AF_PACKET) {
+                    memcpy(mac_addr.addr, &sa->sll_addr, OF_MAC_ADDR_BYTES);
+                    LOG_VERBOSE("Using MAC from interface %s", ifa->ifa_name);
+                    break;
+                }
+            }
+        }
+    }
+    freeifaddrs(ifaddr);
 
     if (port_no == OVSP_LOCAL) {
         ifname = "local";


### PR DESCRIPTION
Reviewer: @harshsin

The kernel used to give us the MAC in the vport added notification, and the old
code was a hack to emulate that. The new code is cleaner and faster.