### PR TITLE
use ccache to build packages faster

### DIFF
--- a/build/build-debian-packages-inner.sh
+++ b/build/build-debian-packages-inner.sh
@@ -2,4 +2,5 @@
 OUTER_UID=$(stat -c '%u' .)
 OUTER_GID=$(stat -c '%g' .)
 trap "chown -R $OUTER_UID:$OUTER_GID ." EXIT
+export PATH=/usr/lib/ccache:$PATH
 make deb

--- a/build/build-debian-packages.sh
+++ b/build/build-debian-packages.sh
@@ -35,7 +35,7 @@ mkdir -p $BUILDDIR/ivs
 #cp build/build-debian-packages-inner.sh $BUILDDIR/build-debian-packages-inner.sh
 rsync --files-from <(./build/files.sh) . "$BUILDDIR/ivs"
 
-docker.io run -e BUILD_ID=$BUILD_ID -e BUILD_OS=$BUILD_OS -v $BUILDDIR:/work -w /work/ivs $DOCKER_IMAGE ./build/build-debian-packages-inner.sh
+docker.io run -e BUILD_ID=$BUILD_ID -e BUILD_OS=$BUILD_OS -v $BUILDDIR:/work -v /tmp/ivs.ccache:/.ccache -w /work/ivs $DOCKER_IMAGE ./build/build-debian-packages-inner.sh
 
 # Copy built packages to pkg/
 OUTDIR=$(readlink -m "pkg/$BUILD_OS/$BUILD_ID")

--- a/build/build-rhel-packages-inner.sh
+++ b/build/build-rhel-packages-inner.sh
@@ -5,6 +5,7 @@ SPEC="/rpmbuild/SOURCES/ivs-7.0.spec"
 OUTER_UID=$(stat -c '%u' $SPEC)
 OUTER_GID=$(stat -c '%g' $SPEC)
 trap "chown -R $OUTER_UID:$OUTER_GID /rpmbuild" EXIT
+export PATH=/usr/lib64/ccache:$PATH
 chown -R root:root /rpmbuild
 
 rpmbuild -bb $SPEC

--- a/build/build-rhel-packages.sh
+++ b/build/build-rhel-packages.sh
@@ -22,7 +22,7 @@ ROOTDIR=$(dirname $(readlink -f $0))/..
 cd "$ROOTDIR"
 
 : Build ID: ${BUILD_ID:=devel}
-
+DOCKER_IMAGE=bigswitch/ivs-builder:centos7
 BUILD_OS=centos7-x86_64
 
 BUILDDIR=$(mktemp -d)
@@ -34,7 +34,7 @@ cp build/build-rhel-packages-inner.sh $BUILDDIR/build-rhel-packages-inner.sh
 cp rhel/ivs-7.0.spec $BUILDDIR/SOURCES
 tar -T <(./build/files.sh) -c -z -f $BUILDDIR/SOURCES/ivs.tar.gz --transform 's,^,ivs/,'
 
-docker.io run -e BUILD_ID=$BUILD_ID -e BUILD_OS=$BUILD_OS -v $BUILDDIR:/rpmbuild bigswitch/ivs-builder:centos7 /rpmbuild/build-rhel-packages-inner.sh
+docker.io run -e BUILD_ID=$BUILD_ID -e BUILD_OS=$BUILD_OS -v $BUILDDIR:/rpmbuild -v /tmp/ivs.ccache:/.ccache $DOCKER_IMAGE /rpmbuild/build-rhel-packages-inner.sh
 
 # Copy built RPMs to pkg/
 OUTDIR=$(readlink -m "pkg/$BUILD_OS/$BUILD_ID")

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -2,3 +2,5 @@ FROM centos:centos7
 MAINTAINER Rich Lane <rlane@bigswitch.com>
 RUN yum groupinstall -y 'Development Tools'
 RUN yum install -y libnl3-devel
+RUN yum install -y epel-release
+RUN yum install -y ccache

--- a/docker/ubuntu14.04/Dockerfile
+++ b/docker/ubuntu14.04/Dockerfile
@@ -1,3 +1,3 @@
 FROM ubuntu:14.04
 MAINTAINER Rich Lane <rlane@bigswitch.com>
-RUN apt-get update && apt-get install -y build-essential pkg-config libnl-3-dev libnl-route-3-dev libnl-genl-3-dev python debhelper
+RUN apt-get update && apt-get install -y build-essential pkg-config libnl-3-dev libnl-route-3-dev libnl-genl-3-dev python debhelper ccache


### PR DESCRIPTION
Reviewer: trivial

ccache needs a persistent cache directory to be useful. We mount
/tmp/ivs.ccache into the containers as .ccache.