### PR TITLE
OVSDriver: ignore duplicate megaflow requests

### DIFF
--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -130,6 +130,7 @@ struct ind_ovs_port {
 struct ind_ovs_kflow {
     struct list_links global_links; /* (global) kflows */
     struct list_links bucket_links; /* (global) kflow_buckets[] */
+    struct tcam_entry tcam_entry; /* (global) megaflow_tcam */
     struct stats stats; /* periodically synchronized with the kernel */
     uint16_t in_port;
     uint16_t num_stats_handles; /* size of stats_handles array */


### PR DESCRIPTION
Reviewer: @harshsin

An upcall thread might request multiple overlapping kflows. This is 
particularly true for inband, where the kflow mask only includes in_port. 
Before megaflows, we handled this case with a hash table keyed on the kflow 
key. This isn't sufficient anymore because different keys can match the same 
megaflow. The fix is to switch from a hashtable to the TCAM datastructure we 
use in the forwarding pipeline.