### PR TITLE
use a single "endpoint" table in l2switch

### DIFF
--- a/oftests/l2switch.x
+++ b/oftests/l2switch.x
@@ -1,23 +1,15 @@
-struct l2_key {
+struct endpoint_key {
     unsigned int vlan;
     unsigned int mac_hi;
     unsigned int mac_lo;
 };
 
-struct l2_value {
+struct endpoint_value {
     unsigned int port;
 };
 
-struct l2_stats {
+struct endpoint_stats {
     /* TODO use 64-bit integers */
     unsigned int packets;
     unsigned int bytes;
-};
-
-struct vlan_key {
-    unsigned int vlan;
-};
-
-struct vlan_value {
-    unsigned int port_bitmap;
 };

--- a/oftests/l2switch_xdr.py
+++ b/oftests/l2switch_xdr.py
@@ -88,7 +88,7 @@ class XDRTypedef(object):
     def unpack(cls, data):
         return cls.unpack_from(xdrlib.Unpacker(data))
 
-class l2_key(XDRStruct):
+class endpoint_key(XDRStruct):
     __slots__ = ['vlan', 'mac_hi', 'mac_lo']
 
     def __init__(self, vlan=None, mac_hi=None, mac_lo=None):
@@ -104,7 +104,7 @@ class l2_key(XDRStruct):
 
     @classmethod
     def unpack_from(cls, unpacker):
-        obj = l2_key()
+        obj = endpoint_key()
         obj.vlan = unpacker.unpack_uint()
         obj.mac_hi = unpacker.unpack_uint()
         obj.mac_lo = unpacker.unpack_uint()
@@ -123,7 +123,7 @@ class l2_key(XDRStruct):
 
     def __repr__(self):
         parts = []
-        parts.append('l2_key(')
+        parts.append('endpoint_key(')
         parts.append('vlan=')
         parts.append(repr(self.vlan))
         parts.append(", ")
@@ -135,7 +135,7 @@ class l2_key(XDRStruct):
         parts.append(')')
         return ''.join(parts)
 
-class l2_value(XDRStruct):
+class endpoint_value(XDRStruct):
     __slots__ = ['port']
 
     def __init__(self, port=None):
@@ -147,7 +147,7 @@ class l2_value(XDRStruct):
 
     @classmethod
     def unpack_from(cls, unpacker):
-        obj = l2_value()
+        obj = endpoint_value()
         obj.port = unpacker.unpack_uint()
         return obj
 
@@ -160,13 +160,13 @@ class l2_value(XDRStruct):
 
     def __repr__(self):
         parts = []
-        parts.append('l2_value(')
+        parts.append('endpoint_value(')
         parts.append('port=')
         parts.append(repr(self.port))
         parts.append(')')
         return ''.join(parts)
 
-class l2_stats(XDRStruct):
+class endpoint_stats(XDRStruct):
     __slots__ = ['packets', 'bytes']
 
     def __init__(self, packets=None, bytes=None):
@@ -180,7 +180,7 @@ class l2_stats(XDRStruct):
 
     @classmethod
     def unpack_from(cls, unpacker):
-        obj = l2_stats()
+        obj = endpoint_stats()
         obj.packets = unpacker.unpack_uint()
         obj.bytes = unpacker.unpack_uint()
         return obj
@@ -196,7 +196,7 @@ class l2_stats(XDRStruct):
 
     def __repr__(self):
         parts = []
-        parts.append('l2_stats(')
+        parts.append('endpoint_stats(')
         parts.append('packets=')
         parts.append(repr(self.packets))
         parts.append(", ")
@@ -205,66 +205,4 @@ class l2_stats(XDRStruct):
         parts.append(')')
         return ''.join(parts)
 
-class vlan_key(XDRStruct):
-    __slots__ = ['vlan']
-
-    def __init__(self, vlan=None):
-        self.vlan = vlan
-
-    @classmethod
-    def pack_into(self, packer, obj):
-        packer.pack_uint(obj.vlan)
-
-    @classmethod
-    def unpack_from(cls, unpacker):
-        obj = vlan_key()
-        obj.vlan = unpacker.unpack_uint()
-        return obj
-
-    def __eq__(self, other):
-        if type(self) != type(other):
-            return False
-        if self.vlan != other.vlan:
-            return False
-        return True
-
-    def __repr__(self):
-        parts = []
-        parts.append('vlan_key(')
-        parts.append('vlan=')
-        parts.append(repr(self.vlan))
-        parts.append(')')
-        return ''.join(parts)
-
-class vlan_value(XDRStruct):
-    __slots__ = ['port_bitmap']
-
-    def __init__(self, port_bitmap=None):
-        self.port_bitmap = port_bitmap
-
-    @classmethod
-    def pack_into(self, packer, obj):
-        packer.pack_uint(obj.port_bitmap)
-
-    @classmethod
-    def unpack_from(cls, unpacker):
-        obj = vlan_value()
-        obj.port_bitmap = unpacker.unpack_uint()
-        return obj
-
-    def __eq__(self, other):
-        if type(self) != type(other):
-            return False
-        if self.port_bitmap != other.port_bitmap:
-            return False
-        return True
-
-    def __repr__(self):
-        parts = []
-        parts.append('vlan_value(')
-        parts.append('port_bitmap=')
-        parts.append(repr(self.port_bitmap))
-        parts.append(')')
-        return ''.join(parts)
-
-__all__ = ['l2_key', 'l2_value', 'l2_stats', 'vlan_key', 'vlan_value']
+__all__ = ['endpoint_key', 'endpoint_value', 'endpoint_stats']

--- a/oftests/lua/l2switch.lua
+++ b/oftests/lua/l2switch.lua
@@ -19,8 +19,6 @@
 -- OFTests against.
 --
 -- TODO send packet-in instead of dropping
--- TODO use a single "endpoint" OpenFlow table
--- TODO remove limitation of 32 ports
 -- TODO send LLDPs to controller
 
 local fields = fields
@@ -28,67 +26,70 @@ local bit_check, flood
 local xdr = require("l2switch_xdr")
 
 local l2_table = hashtable.create({ "vlan", "mac_hi", "mac_lo" }, { "port", "stats" })
-local l2_stats = {}
 
-register_table("l2", {
-    parse_key=xdr.read_l2_key,
-    parse_value=xdr.read_l2_value,
+local vlan_table = {} -- vlan -> { port -> refcount }
+for vlan = 0, 4095 do
+    vlan_table[vlan] = {}
+end
+
+local function vlan_add_member(vlan, port)
+    vlan_entry = vlan_table[vlan]
+    vlan_entry[port] = (vlan_entry[port] or 0) + 1
+end
+
+local function vlan_remove_member(vlan, port)
+    vlan_entry = vlan_table[vlan]
+    local refcount = vlan_entry[port]
+    if refcount > 1 then
+        vlan_entry[port] = refcount - 1
+    else
+        vlan_entry[port] = nil
+    end
+end
+
+local endpoints = {} -- cookie -> { stats, port }
+
+register_table("endpoint", {
+    parse_key=xdr.read_endpoint_key,
+    parse_value=xdr.read_endpoint_value,
 
     add=function(k, v, cookie)
-        log("l2_add %p: vlan=%u mac=%04x%08x -> port %u", cookie, k.vlan, k.mac_hi, k.mac_lo, v.port)
-        l2_stats[cookie] = stats.alloc()
-        l2_table:insert(k, { port=v.port, stats=l2_stats[cookie] })
+        log("endpoint add %p: vlan=%u mac=%04x%08x -> port %u", cookie, k.vlan, k.mac_hi, k.mac_lo, v.port)
+        local s = stats.alloc()
+        l2_table:insert(k, { port=v.port, stats=s })
+        vlan_add_member(k.vlan, v.port)
+        endpoints[cookie] = { port=v.port, stats=s }
     end,
 
     modify=function(k, v, cookie)
-        log("l2_modify %p: vlan=%u mac=%04x%08x -> port %u", cookie, k.vlan, k.mac_hi, k.mac_lo, v.port)
-        l2_table:insert(k, { port=v.port, stats=l2_stats[cookie] })
+        log("endpoint modify %p: vlan=%u mac=%04x%08x -> port %u", cookie, k.vlan, k.mac_hi, k.mac_lo, v.port)
+        local e = endpoints[cookie]
+        l2_table:insert(k, { port=v.port, stats=e.stats })
+        vlan_remove_member(k.vlan, e.port) -- remove old port from VLAN
+        vlan_add_member(k.vlan, v.port) -- add new port to VLAN
     end,
 
     delete=function(k, cookie)
-        log("l2_delete %p: vlan=%u mac=%04x%08x", cookie, k.vlan, k.mac_hi, k.mac_lo)
-        stats.free(l2_stats[cookie])
-        l2_stats[cookie] = nil
+        log("endpoint delete %p: vlan=%u mac=%04x%08x", cookie, k.vlan, k.mac_hi, k.mac_lo)
+        local e = endpoints[cookie]
         l2_table:remove(k)
+        vlan_remove_member(k.vlan, e.port)
+        stats.free(e.stats)
+        endpoints[cookie] = nil
     end,
 
     get_stats=function(k, writer, cookie)
-        log("l2_get_stats %p: vlan=%u mac=%04x%08x", cookie, k.vlan, k.mac_hi, k.mac_lo)
-        local packets, bytes = stats.get(l2_stats[cookie])
-        xdr.write_l2_stats(writer, { packets=packets, bytes=bytes })
+        log("endpoint get_stats %p: vlan=%u mac=%04x%08x", cookie, k.vlan, k.mac_hi, k.mac_lo)
+        local e = endpoints[cookie]
+        local packets, bytes = stats.get(e.stats)
+        xdr.write_endpoint_stats(writer, { packets=packets, bytes=bytes })
     end
-})
-
-local vlan_table = hashtable.create({ "vlan" }, { "port_bitmap" })
-
-register_table("vlan", {
-    parse_key=xdr.read_vlan_key,
-    parse_value=xdr.read_vlan_value,
-
-    add=function(k, v, cookie)
-        log("vlan_add %p: vlan=%u -> port_bitmap %08x", cookie, k.vlan, v.port_bitmap)
-        vlan_table:insert(k, v)
-    end,
-
-    modify=function(k, v, cookie)
-        log("vlan_modify %p: vlan=%u -> port_bitmap %08x", cookie, k.vlan, v.port_bitmap)
-        vlan_table:insert(k, v)
-    end,
-
-    delete=function(k, cookie)
-        log("vlan_delete %p: vlan=%u", cookie, k.vlan)
-        vlan_table:remove(k)
-    end,
 })
 
 function ingress()
-    local vlan_entry = vlan_table:lookup({ vlan=fields.vlan_vid })
-    if not vlan_entry then
-        trace("VLAN lookup failure, dropping")
-        return
-    end
+    local vlan_entry = vlan_table[fields.vlan_vid]
 
-    if not bit_check(vlan_entry.port_bitmap, fields.in_port) then
+    if not vlan_entry[fields.in_port] then
         trace("Port %u not allowed on VLAN %u, dropping", fields.in_port, fields.vlan_vid)
         return
     end
@@ -123,13 +124,7 @@ function ingress()
 end
 
 function flood(vlan_entry)
-    for port = 0, 31 do
-        if bit_check(vlan_entry.port_bitmap, port) then
-            output(port)
-        end
+    for port in pairs(vlan_entry) do
+        output(port)
     end
-end
-
-function bit_check(bitmap, index)
-    return bit.band(bitmap, bit.lshift(1, index)) ~= 0
 end

--- a/oftests/lua/l2switch_xdr.lua
+++ b/oftests/lua/l2switch_xdr.lua
@@ -91,7 +91,7 @@ local function write_string(writer, x, max)
     writer.fstring(x)
 end
 
-function public.read_l2_key(reader)
+function public.read_endpoint_key(reader)
     local obj = {}
 obj.vlan = read_uint(reader)
 obj.mac_hi = read_uint(reader)
@@ -99,52 +99,32 @@ obj.mac_lo = read_uint(reader)
     return obj
 end
 
-function public.write_l2_key(writer, obj)
+function public.write_endpoint_key(writer, obj)
 write_uint(writer, obj.vlan)
 write_uint(writer, obj.mac_hi)
 write_uint(writer, obj.mac_lo)
 end
 
-function public.read_l2_value(reader)
+function public.read_endpoint_value(reader)
     local obj = {}
 obj.port = read_uint(reader)
     return obj
 end
 
-function public.write_l2_value(writer, obj)
+function public.write_endpoint_value(writer, obj)
 write_uint(writer, obj.port)
 end
 
-function public.read_l2_stats(reader)
+function public.read_endpoint_stats(reader)
     local obj = {}
 obj.packets = read_uint(reader)
 obj.bytes = read_uint(reader)
     return obj
 end
 
-function public.write_l2_stats(writer, obj)
+function public.write_endpoint_stats(writer, obj)
 write_uint(writer, obj.packets)
 write_uint(writer, obj.bytes)
-end
-
-function public.read_vlan_key(reader)
-    local obj = {}
-obj.vlan = read_uint(reader)
-    return obj
-end
-
-function public.write_vlan_key(writer, obj)
-write_uint(writer, obj.vlan)
-end
-
-function public.read_vlan_value(reader)
-    local obj = {}
-obj.port_bitmap = read_uint(reader)
-    return obj
-end
-
-function public.write_vlan_value(writer, obj)
-write_uint(writer, obj.port_bitmap)
 end
 
 return public

--- a/oftests/lua_l2switch.py
+++ b/oftests/lua_l2switch.py
@@ -35,42 +35,28 @@ def parse_mac_words(mac):
 def format_mac_words(mac_hi, mac_lo):
     return ':'.join("%02x" % ord(x) for x in struct.pack("!HL", mac_hi, mac_lo))
 
-def insert_l2(self, vlan, mac, port):
+def insert_endpoint(self, vlan, mac, port):
     mac_hi, mac_lo = parse_mac_words(mac)
 
-    key = l2switch_xdr.l2_key(vlan=vlan, mac_hi=mac_hi, mac_lo=mac_lo)
-    value = l2switch_xdr.l2_value(port=port)
+    key = l2switch_xdr.endpoint_key(vlan=vlan, mac_hi=mac_hi, mac_lo=mac_lo)
+    value = l2switch_xdr.endpoint_value(port=port)
 
     msg = ofp.message.bsn_gentable_entry_add(
-        table_id=self.gentable_ids['l2'],
+        table_id=self.gentable_ids['endpoint'],
         key=[ofp.bsn_tlv.data(key.pack())],
         value=[ofp.bsn_tlv.data(value.pack())])
     self.controller.message_send(msg)
 
-def get_l2_stats(self):
-    request = ofp.message.bsn_gentable_entry_stats_request(table_id=self.gentable_ids['l2'])
+def get_endpoint_stats(self):
+    request = ofp.message.bsn_gentable_entry_stats_request(table_id=self.gentable_ids['endpoint'])
     stats = get_stats(self, request)
     result = {}
     for entry in stats:
-        key = l2switch_xdr.l2_key.unpack(entry.key[0].value)
-        stats = l2switch_xdr.l2_stats.unpack(entry.stats[0].value)
+        key = l2switch_xdr.endpoint_key.unpack(entry.key[0].value)
+        stats = l2switch_xdr.endpoint_stats.unpack(entry.stats[0].value)
         result[(key.vlan, format_mac_words(key.mac_hi, key.mac_lo))] = (stats.packets, stats.bytes)
 
     return result
-
-def insert_vlan(self, vlan, ports):
-    port_bitmap = 0
-    for port in ports:
-        port_bitmap |= (1 << port)
-
-    key = l2switch_xdr.vlan_key(vlan=vlan)
-    value = l2switch_xdr.vlan_value(port_bitmap=port_bitmap)
-
-    msg = ofp.message.bsn_gentable_entry_add(
-        table_id=self.gentable_ids['vlan'],
-        key=[ofp.bsn_tlv.data(key.pack())],
-        value=[ofp.bsn_tlv.data(value.pack())])
-    self.controller.message_send(msg)
 
 class L2Forwarding(lua_common.BaseTest):
     """
@@ -80,11 +66,9 @@ class L2Forwarding(lua_common.BaseTest):
     sources = ["l2switch_xdr", "l2switch"]
 
     def runTest(self):
-        insert_vlan(self, vlan=1, ports=[1, 2])
-        insert_vlan(self, vlan=2, ports=[3])
-        insert_l2(self, vlan=1, mac="00:00:00:00:00:01", port=1)
-        insert_l2(self, vlan=1, mac="00:00:00:00:00:02", port=2)
-        insert_l2(self, vlan=2, mac="00:00:00:00:00:03", port=3)
+        insert_endpoint(self, vlan=1, mac="00:00:00:00:00:01", port=1)
+        insert_endpoint(self, vlan=1, mac="00:00:00:00:00:02", port=2)
+        insert_endpoint(self, vlan=2, mac="00:00:00:00:00:03", port=3)
         do_barrier(self.controller)
         verify_no_errors(self.controller)
 
@@ -152,11 +136,9 @@ class ManyPackets(lua_common.BaseTest):
     sources = ["l2switch_xdr", "l2switch"]
 
     def runTest(self):
-        insert_vlan(self, vlan=1, ports=[1, 2])
-        insert_vlan(self, vlan=2, ports=[3])
-        insert_l2(self, vlan=1, mac="00:00:00:00:00:01", port=1)
-        insert_l2(self, vlan=1, mac="00:00:00:00:00:02", port=2)
-        insert_l2(self, vlan=2, mac="00:00:00:00:00:03", port=3)
+        insert_endpoint(self, vlan=1, mac="00:00:00:00:00:01", port=1)
+        insert_endpoint(self, vlan=1, mac="00:00:00:00:00:02", port=2)
+        insert_endpoint(self, vlan=2, mac="00:00:00:00:00:03", port=3)
         do_barrier(self.controller)
         verify_no_errors(self.controller)
 
@@ -178,9 +160,8 @@ class Stats(lua_common.BaseTest):
     sources = ["l2switch_xdr", "l2switch"]
 
     def runTest(self):
-        insert_vlan(self, vlan=1, ports=[1, 2])
-        insert_l2(self, vlan=1, mac="00:00:00:00:00:01", port=1)
-        insert_l2(self, vlan=1, mac="00:00:00:00:00:02", port=2)
+        insert_endpoint(self, vlan=1, mac="00:00:00:00:00:01", port=1)
+        insert_endpoint(self, vlan=1, mac="00:00:00:00:00:02", port=2)
         do_barrier(self.controller)
         verify_no_errors(self.controller)
 
@@ -191,6 +172,6 @@ class Stats(lua_common.BaseTest):
         self.dataplane.send(1, pkt)
         verify_packets(self, pkt, [2])
 
-        l2_stats = get_l2_stats(self)
-        self.assertEqual(l2_stats[(1, '00:00:00:00:00:01')], (1, 100))
-        self.assertEqual(l2_stats[(1, '00:00:00:00:00:02')], (0, 0))
+        endpoint_stats = get_endpoint_stats(self)
+        self.assertEqual(endpoint_stats[(1, '00:00:00:00:00:01')], (1, 100))
+        self.assertEqual(endpoint_stats[(1, '00:00:00:00:00:02')], (0, 0))


### PR DESCRIPTION
Reviewer: @harshsin

This is a prototype for reducing redundancy in OpenFlow tables. The controller
can program a small number of abstract tables, and the Lua code can translate
them into a lower level, more efficient set of tables used for forwarding.