### PR TITLE
OVSDriver: add more performance debug counters

### DIFF
--- a/modules/OVSDriver/module/src/pktin_socket.c
+++ b/modules/OVSDriver/module/src/pktin_socket.c
@@ -23,6 +23,8 @@
 
 DEBUG_COUNTER(pktin_ratelimited, "ovsdriver.pktin.ratelimited",
               "Dropped packet-in because of the ratelimiter");
+DEBUG_COUNTER(pktin_socket_ready, "ovsdriver.pktin.socket_ready",
+              "Packet-in socket ready for reading");
 
 static int
 ind_ovs_pktin_socket_recv(struct nl_msg *msg, void *arg)
@@ -78,6 +80,7 @@ ind_ovs_pktin_socket_ready(int socket_id, void *cookie,
                            int read_ready, int write_ready, int error_seen)
 {
     struct ind_ovs_pktin_socket *soc = cookie;
+    debug_counter_inc(&pktin_socket_ready);
     nl_recvmsgs_default(soc->pktin_socket);
 }
 

--- a/modules/OVSDriver/module/src/upcall.c
+++ b/modules/OVSDriver/module/src/upcall.c
@@ -124,6 +124,7 @@ DEBUG_COUNTER(respawn_time, "ovsdriver.upcall.respawn_time", "Total time in micr
 SHARED_DEBUG_COUNTER(upcall, "ovsdriver.upcall", "Upcall from the kernel");
 SHARED_DEBUG_COUNTER(wakeup, "ovsdriver.upcall.wakeup", "Upcall process woken up");
 SHARED_DEBUG_COUNTER(upcall_time, "ovsdriver.upcall.time", "Total time in microseconds spent handling upcalls");
+SHARED_DEBUG_COUNTER(kflow_socket_full, "ovsdriver.upcall.kflow_socket_full", "Kernel flow socket full");
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC optimize (4)
@@ -390,6 +391,7 @@ ind_ovs_upcall_request_kflow(struct ind_ovs_upcall_thread *thread,
     if (written < 0) {
         if (errno == EAGAIN) {
             AIM_LOG_VERBOSE("kflow socket buffer full");
+            debug_counter_inc(&kflow_socket_full);
         } else {
             AIM_LOG_ERROR("Failed to write to kflow socket: %s", strerror(errno));
         }


### PR DESCRIPTION
Reviewer: @harshsin

These counters are useful for debugging drops of packet-ins, kflow requests, 
and upcalls.