### PR TITLE
OVSDriver: add API to get link state

### DIFF
--- a/modules/OVSDriver/module/src/vport.c
+++ b/modules/OVSDriver/module/src/vport.c
@@ -1124,3 +1124,10 @@ get_packet_stats(struct stats_handle *handle)
     stats_get(handle, &stats);
     return stats.packets;
 }
+
+bool
+ind_ovs_port_running(of_port_no_t port_no)
+{
+    struct ind_ovs_port *port = ind_ovs_port_lookup(port_no);
+    return port && port->ifflags & IFF_RUNNING;
+}

--- a/modules/ivs/module/inc/ivs/ivs.h
+++ b/modules/ivs/module/inc/ivs/ivs.h
@@ -164,5 +164,6 @@ indigo_error_t ind_ovs_pktin(of_port_no_t in_port, uint8_t *data,
                              unsigned int len, uint8_t reason, uint64_t metadata,
                              struct ind_ovs_parsed_key *pkey);
 void ind_ovs_handle_multicast(void);
+bool ind_ovs_port_running(of_port_no_t port_no);
 
 #endif


### PR DESCRIPTION
Reviewer: @harshsin

This is useful in the implementation of select groups in the pipeline.