### PR TITLE
OVSDriver: disable LRO on port add

### DIFF
--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -250,6 +250,7 @@ void ind_ovs_nlmsg_freelist_free(struct nl_msg *msg);
 indigo_error_t ind_ovs_get_interface_flags(const char *ifname, int *flags);
 indigo_error_t ind_ovs_set_interface_flags(const char *ifname, int flags);
 void ind_ovs_get_interface_features(const char *ifname, uint32_t *curr, uint32_t *advertised, uint32_t *supported, uint32_t *peer, int version);
+indigo_error_t ind_ovs_set_ethtool_flags(const char *ifname, uint32_t flags, uint32_t mask);
 indigo_error_t write_file(const char *filename, const char *str);
 
 /* Sends msg, frees it, and waits for a reply. */

--- a/modules/OVSDriver/module/src/vport.c
+++ b/modules/OVSDriver/module/src/vport.c
@@ -27,6 +27,7 @@
 #include <netlink/cache.h>
 #include <netlink/route/link.h>
 #include <netlink/route/qdisc.h>
+#include <linux/ethtool.h>
 
 #ifndef _LINUX_IF_H
 /* Some versions of libnetlink include linux/if.h, which conflicts with net/if.h. */
@@ -322,6 +323,13 @@ ind_ovs_port_added(uint32_t port_no, const char *ifname,
     } else {
         /* Not a netdev, fake the interface flags */
         port->ifflags = IFF_UP;
+    }
+
+    if (type == OVS_VPORT_TYPE_NETDEV) {
+        /* Disable LRO */
+        if (ind_ovs_set_ethtool_flags(port->ifname, 0, ETH_FLAG_LRO) < 0) {
+            AIM_LOG_WARN("Failed to disable LRO on interface %s", port->ifname);
+        }
     }
 
     port->is_uplink = ind_ovs_uplink_check_by_name(port->ifname);


### PR DESCRIPTION
Reviewer: @harshsin

If LRO is enabled I see large (but not over MTU) packets being lost after 
missing in the kernel flowtable. They fail a skb->len <= mss check in 
tcp_gso_segment. It's not clear why ixgbe marks these packets as needing GSO. 
Disabling LRO works around the issue, and I found that OVS is doing the same 
thing.