### PR TITLE
hitless restart

### DIFF
--- a/modules/OVSDriver/module/inc/OVSDriver/ovsdriver.h
+++ b/modules/OVSDriver/module/inc/OVSDriver/ovsdriver.h
@@ -22,7 +22,7 @@
 
 struct xbuf;
 
-indigo_error_t ind_ovs_init(const char *datapath_name);
+indigo_error_t ind_ovs_init(const char *datapath_name, bool hitless);
 void ind_ovs_finish(void);
 void ind_ovs_enable(void);
 

--- a/modules/OVSDriver/module/src/hitless.c
+++ b/modules/OVSDriver/module/src/hitless.c
@@ -1,0 +1,69 @@
+/****************************************************************
+ *
+ *        Copyright 2015, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+#include "ovs_driver_int.h"
+#include <indigo/of_state_manager.h>
+
+/*
+ * Take over management of the kernel flowtable
+ *
+ * If ind_ovs_hitless is true then until this point we have not touched the
+ * kernel flowtable. Flows that were active when the previous instance of
+ * IVS died have continued using their kernel flows while this IVS booted
+ * and was configured by the controller. New flows have been handled by the
+ * upcall threads and likely dropped.
+ *
+ * The controller sends this message to tell us that it has finished pushing
+ * OpenFlow table entries and we're ready to manage the existing flows.
+ *
+ * Currently this just flushes the kernel flowtable and relies on the upcall
+ * threads to figure out what should go back into the kernel flowtable.
+ * Future work is to read the flows from the kernel, validate them against the
+ * new userspace forwarding state, and modify them if necessary.
+ */
+static void
+handle_takeover(indigo_cxn_id_t cxn_id, of_object_t *msg)
+{
+    AIM_LOG_INFO("Received takeover message");
+    if (ind_ovs_hitless) {
+        ind_ovs_kflow_flush();
+        ind_ovs_hitless = false;
+    } else {
+        AIM_LOG_VERBOSE("Not in hitless restart mode, ignoring takeover message");
+    }
+}
+
+static indigo_core_listener_result_t
+message_listener(indigo_cxn_id_t cxn_id, of_object_t *msg)
+{
+    switch (msg->object_id) {
+    case OF_BSN_TAKEOVER:
+        handle_takeover(cxn_id, msg);
+        return INDIGO_CORE_LISTENER_RESULT_DROP;
+
+    default:
+        return INDIGO_CORE_LISTENER_RESULT_PASS;
+    }
+}
+
+void
+ind_ovs_hitless_init(void)
+{
+    indigo_core_message_listener_register(message_listener);
+}

--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -174,6 +174,7 @@ void ind_ovs_kflow_sync_stats(struct ind_ovs_kflow *kflow);
 void ind_ovs_kflow_invalidate(struct ind_ovs_kflow *kflow);
 void ind_ovs_kflow_invalidate_all(void);
 void ind_ovs_kflow_expire(void);
+void ind_ovs_kflow_flush(void);
 void ind_ovs_kflow_module_init(void);
 
 /* Management of the port set */
@@ -217,6 +218,9 @@ void ind_ovs_vlan_stats_init(void);
 /* Interface of the barrier submodule */
 void ind_ovs_barrier_init(void);
 void ind_ovs_barrier_defer_revalidation_internal(void);
+
+/* Interface of the hitless submodule */
+void ind_ovs_hitless_init(void);
 
 /* Log Netlink attributes in human readable form */
 void ind_ovs_dump_nested(const struct nlattr *nla, void (*cb)(const struct nlattr *attr));
@@ -306,5 +310,11 @@ extern uint32_t ind_ovs_salt;
  * pktout path.
  */
 extern struct ind_ovs_pktin_socket ind_ovs_pktout_soc;
+
+/*
+ * Enable hitless restart. Kernel flow revalidation is disabled
+ * until a takeover message is received from the controller.
+ */
+extern bool ind_ovs_hitless;
 
 #endif

--- a/targets/ivs/ivs.8
+++ b/targets/ivs/ivs.8
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH IVS 8 "June 27, 2013"
+.TH IVS 8 "June 16, 2015"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -56,6 +56,9 @@ Write log messages to syslog instead of stderr.
 .TP
 \fB--internal-port \fIname\fR
 Add an internal port. This creates a netdev to which you can assign an IP address.
+.TP
+\fB--hitless\fR
+Enable hitless restart. Requires a compatible controller.
 .TP
 \fB--help\fR
 Print usage information.

--- a/targets/ivs/main.c
+++ b/targets/ivs/main.c
@@ -106,6 +106,7 @@ static char *config_filename = NULL;
 static char *openflow_version = NULL;
 static char *pipeline = NULL;
 static char pidfile_path[PATH_MAX];
+static bool hitless;
 
 static int count_char(const char *str, char c)
 {
@@ -192,6 +193,7 @@ parse_options(int argc, char **argv)
             OPT_PIPELINE,
             OPT_INBAND_VLAN,
             OPT_INTERNAL_PORT,
+            OPT_HITLESS,
         };
 
         static struct option long_options[] = {
@@ -206,6 +208,7 @@ parse_options(int argc, char **argv)
             {"uplink",      required_argument, 0,  'u' },
             {"inband-vlan", required_argument, 0,  OPT_INBAND_VLAN },
             {"internal-port", required_argument, 0, OPT_INTERNAL_PORT },
+            {"hitless",     no_argument,       0, OPT_HITLESS },
             {"help",        no_argument,       0,  'h' },
             {"version",     no_argument,       0,  OPT_VERSION },
             /* Undocumented options */
@@ -289,6 +292,10 @@ parse_options(int argc, char **argv)
             internal_ports = biglist_append(internal_ports, optarg);
             break;
 
+        case OPT_HITLESS:
+            hitless = true;
+            break;
+
         case 'h':
         case '?':
             printf("ivs: Indigo Virtual Switch\n");
@@ -306,6 +313,7 @@ parse_options(int argc, char **argv)
             printf("  --syslog                    Log to syslog instead of stderr\n");
             printf("  --inband-vlan=VLAN          Enable in-band management on the specified VLAN\n");
             printf("  --internal-port=NAME        Create a port with the given name connected to the datapath\n");
+            printf("  --hitless                   Preserve kernel flows until controller pushes configuration\n");
             printf("  -h,--help                   Display this help message and exit\n");
             printf("  --version                   Display version information and exit\n");
             exit(c == 'h' ? 0 : 1);
@@ -624,7 +632,7 @@ aim_main(int argc, char* argv[])
         return 1;
     }
 
-    if (ind_ovs_init(datapath_name) < 0) {
+    if (ind_ovs_init(datapath_name, hitless) < 0) {
         AIM_LOG_FATAL("Failed to initialize OVSDriver module");
         return 1;
     }

--- a/tests/hitless.py
+++ b/tests/hitless.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""
+This test verifies that an IVS started with the --hitless flag waits until it
+receives a bsn_takeover message before revalidating the kernel flowtable.
+"""
+import subprocess
+import logging
+import time
+import os
+import signal
+import sys
+
+sys.path.insert(1, "submodules/loxigen-artifacts/pyloxi")
+import loxi.of14 as ofp
+import loxi.connection
+from loxi.pp import pp
+
+IVS = "./targets/ivs/build/gcc-local/bin/ivs"
+
+logging.basicConfig(level=logging.INFO)
+
+logfile = file("ivs.log", "w")
+ivs = None
+
+def start_ivs():
+    global ivs
+    logging.info("Starting IVS")
+    ivs = subprocess.Popen(
+        [IVS, '-v', '-l', '127.0.0.1:6634', '--hitless', '-V', '1.3'],
+        stdout=logfile, stderr=logfile)
+
+def insert_flows():
+    logging.info("Inserting flows")
+    cxn = loxi.connection.connect("127.0.0.1", port=6634)
+    port_descs = cxn.transact_multipart(ofp.message.port_desc_stats_request())
+    port_numbers = { x.name: x.port_no for x in port_descs }
+
+    cxn.send(ofp.message.flow_add(
+        match=ofp.match([
+            ofp.oxm.in_port(port_numbers["test1"])]),
+        instructions=[
+            ofp.instruction.apply_actions([
+                ofp.action.output(port_numbers["test2"])])]))
+    cxn.send(ofp.message.flow_add(
+        match=ofp.match([
+            ofp.oxm.in_port(port_numbers["test2"])]),
+        instructions=[
+            ofp.instruction.apply_actions([
+                ofp.action.output(port_numbers["test1"])])]))
+    cxn.send(ofp.message.bsn_takeover())
+    cxn.transact(ofp.message.barrier_request())
+
+def cmd(*args):
+    logging.debug("Running %s", ' '.join(args))
+    subprocess.check_call(args)
+
+
+subprocess.call(["ivs-ctl", "del-dp"])
+
+try:
+    if os.path.exists("/var/run/netns/test1"):
+        cmd("ip", "netns", "delete", "test1")
+
+    if os.path.exists("/var/run/netns/test2"):
+        cmd("ip", "netns", "delete", "test2")
+
+    start_ivs()
+
+    cmd("ip", "netns", "add", "test1")
+    cmd("ip", "netns", "add", "test2")
+
+    cmd("ip", "link", "add", "name", "test1", "type", "veth", "peer", "name", "test1-peer")
+    cmd("ip", "link", "set", "test1-peer", "up", "netns", "test1", "name", "eth0")
+    cmd("ip", "netns", "exec", "test1", "ip", "addr", "add", "dev", "eth0", "192.168.248.1/24")
+
+    cmd("ip", "link", "add", "name", "test2", "type", "veth", "peer", "name", "test2-peer")
+    cmd("ip", "link", "set", "test2-peer", "up", "netns", "test2", "name", "eth0")
+    cmd("ip", "netns", "exec", "test2", "ip", "addr", "add", "dev", "eth0", "192.168.248.2/24")
+
+    cmd("ivs-ctl", "add-port", "test1")
+    cmd("ivs-ctl", "add-port", "test2")
+
+    insert_flows()
+
+    logging.info("Normal ping")
+    cmd("ip", "netns", "exec", "test1", "ping", "-c", "10", "-i", "0.1", "192.168.248.2")
+    ivs.kill()
+
+    logging.info("Pinging while IVS is dead")
+    cmd("ip", "netns", "exec", "test1", "ping", "-c", "10", "-i", "0.1", "192.168.248.2")
+
+    start_ivs()
+
+    logging.info("Pinging after IVS has restarted but before takeover")
+    cmd("ip", "netns", "exec", "test1", "ping", "-c", "10", "-i", "0.1", "192.168.248.2")
+
+    insert_flows()
+
+    logging.info("Pinging after takeover")
+    cmd("ip", "netns", "exec", "test1", "ping", "-c", "10", "-i", "0.1", "192.168.248.2")
+finally:
+    if ivs:
+        ivs.kill()
+
+    if os.path.exists("/var/run/netns/test1"):
+        cmd("ip", "netns", "delete", "test1")
+
+    if os.path.exists("/var/run/netns/test2"):
+        cmd("ip", "netns", "delete", "test2")


### PR DESCRIPTION
Reviewer: @harshsin

The goal of these changes is to reduce the interval after restarting IVS
during which packets from long-lived flows are lost. See the big comment in
hitless.c for implementation details.

This assumes a proactive OpenFlow controller which sends the bsn_takeover
experimenter message after it has pushed all table entries. The barrier
message might have been used instead, but since OpenFlow uses the same
barrier message for both message ordering and dataplane commit it's too
likely that a controller will send a barrier before it's finished pushing
tables.