### PR TITLE
OVSDriver: handle link status changes for new/delete also

### DIFF
--- a/modules/OVSDriver/module/src/vport.c
+++ b/modules/OVSDriver/module/src/vport.c
@@ -1002,14 +1002,6 @@ link_change_cb(struct nl_cache *cache,
         return;
     }
 
-    /*
-     * Ignore additions/deletions, already handled by
-     * ind_ovs_handle_vport_multicast.
-     */
-    if (action != 5 /* NL_ACT_CHANGE */) {
-        return;
-    }
-
     /* Ignore interfaces not connected to our datapath. */
     struct ind_ovs_port *port = ind_ovs_port_lookup_by_name(ifname);
     if (port == NULL) {


### PR DESCRIPTION
Reviewer: @harshsin

It's possible for the link-add Netlink message to arrive after the openvswitch 
vport-add Netlink message, and to carry a status change such as link-up. The 
previous code would have dropped this message and never seen a link-up 
notification for that port.