### PR TITLE
OVSDriver: enable GRO on uplinks

### DIFF
--- a/modules/OVSDriver/module/src/ovs_driver_int.h
+++ b/modules/OVSDriver/module/src/ovs_driver_int.h
@@ -255,6 +255,7 @@ indigo_error_t ind_ovs_get_interface_flags(const char *ifname, int *flags);
 indigo_error_t ind_ovs_set_interface_flags(const char *ifname, int flags);
 void ind_ovs_get_interface_features(const char *ifname, uint32_t *curr, uint32_t *advertised, uint32_t *supported, uint32_t *peer, int version);
 indigo_error_t ind_ovs_set_ethtool_flags(const char *ifname, uint32_t flags, uint32_t mask);
+indigo_error_t ind_ovs_set_ethtool_gro(const char *ifname, bool enabled);
 indigo_error_t write_file(const char *filename, const char *str);
 
 /* Sends msg, frees it, and waits for a reply. */

--- a/modules/OVSDriver/module/src/util.c
+++ b/modules/OVSDriver/module/src/util.c
@@ -572,6 +572,24 @@ ind_ovs_set_ethtool_flags(const char *ifname, uint32_t flags, uint32_t mask)
 }
 
 indigo_error_t
+ind_ovs_set_ethtool_gro(const char *ifname, bool enabled)
+{
+    struct ethtool_value eval = {
+        .cmd = ETHTOOL_SGRO,
+        .data = enabled,
+    };
+
+    indigo_error_t err = ind_ovs_ethtool_ioctl(ifname, &eval);
+    if (err < 0) {
+        LOG_ERROR("failed to %s GRO on %s: %s",
+                  enabled ? "enable" : "disable", ifname, strerror(errno));
+        return err;
+    }
+
+    return INDIGO_ERROR_NONE;
+}
+
+indigo_error_t
 write_file(const char *filename, const char *str)
 {
     int fd = open(filename, O_WRONLY);


### PR DESCRIPTION
Reviewer: @harshsin

Unlike LRO, GRO should be safe to enable when bridging.